### PR TITLE
chore(IDE): Fix prettier indent conflicts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.organizeImports": false
   },


### PR DESCRIPTION
Prettier indent issue occurs with VSCode IDE. This PR prevents VSCode do not format code on save so that fixes issue adove.