### PR TITLE
fix(Species): static fields return an empty array

### DIFF
--- a/src/entity/Species.mts
+++ b/src/entity/Species.mts
@@ -902,8 +902,8 @@ export abstract class Species implements Comparable {
   public static readonly Spectrier = SpeciesImpl.of(897, 'Spectrier')
   public static readonly Calyrex = SpeciesImpl.of(898, 'Calyrex')
 
-  protected static readonly legendaries: Species[] = []
-  protected static readonly ultrabeasts: Species[] = []
+  protected static readonly legendaries: Set<Species> = new Set()
+  protected static readonly ultrabeasts: Set<Species> = new Set()
   protected static readonly allPokemons: Set<Species> = new Set()
 
   protected constructor(
@@ -914,21 +914,21 @@ export abstract class Species implements Comparable {
   }
 
   /**
-   * Gets the immutable readonly array of species that are considered legendary.
+   * Gets the immutable set of species that are considered legendary.
    *
-   * @returns {ReadonlyArray<Species>} The immutable array of legendary pokemons
+   * @returns {ReadonlySet<Species>} The immutable set of species that are considered legendary
    */
-  public static getLegendaries(): ReadonlyArray<Species> {
-    return [...Species.legendaries]
+  public static getLegendaries(): ReadonlySet<Species> {
+    return new Set(Species.legendaries)
   }
 
   /**
-   * Gets the immutable readonly array of species that are considered ultrabeast.
+   * Gets the immutable set of species that are considered ultrabeasts.
    *
-   * @returns {ReadonlyArray<Species>} The immutable array of ultrabeast pokemons
+   * @returns {ReadonlySet<Species>} The immutable set of species that are considered ultrabeast
    */
-  public static getUltrabeasts(): ReadonlyArray<Species> {
-    return [...Species.ultrabeasts]
+  public static getUltrabeasts(): ReadonlySet<Species> {
+    return new Set(Species.ultrabeasts)
   }
 
   /**

--- a/src/entity/Species.mts
+++ b/src/entity/Species.mts
@@ -902,15 +902,11 @@ export abstract class Species implements Comparable {
   public static readonly Spectrier = SpeciesImpl.of(897, 'Spectrier')
   public static readonly Calyrex = SpeciesImpl.of(898, 'Calyrex')
 
-  protected static readonly legendaries: Set<Species> = new Set()
-  protected static readonly ultrabeasts: Set<Species> = new Set()
-  protected static readonly allPokemons: Set<Species> = new Set()
-
   protected constructor(
     protected readonly dex: number,
     protected readonly name: string
   ) {
-    Species.allPokemons.add(this)
+    SpeciesImpl.allPokemons.add(this)
   }
 
   /**
@@ -919,7 +915,7 @@ export abstract class Species implements Comparable {
    * @returns {ReadonlySet<Species>} The immutable set of species that are considered legendary
    */
   public static getLegendaries(): ReadonlySet<Species> {
-    return new Set(Species.legendaries)
+    return new Set(SpeciesImpl.legendaries)
   }
 
   /**
@@ -928,7 +924,7 @@ export abstract class Species implements Comparable {
    * @returns {ReadonlySet<Species>} The immutable set of species that are considered ultrabeast
    */
   public static getUltrabeasts(): ReadonlySet<Species> {
-    return new Set(Species.ultrabeasts)
+    return new Set(SpeciesImpl.ultrabeasts)
   }
 
   /**
@@ -937,7 +933,7 @@ export abstract class Species implements Comparable {
    * @returns {ReadonlySet<Species>} The readonly set of all the pokemon species
    */
   public static getAllPokemons(): ReadonlySet<Species> {
-    return new Set([...Species.allPokemons])
+    return new Set(SpeciesImpl.allPokemons)
   }
 
   /**
@@ -958,7 +954,7 @@ export abstract class Species implements Comparable {
    * @see {@link has has()}
    */
   public static getFromName(name: string): Species | null {
-    for (const pokemon of Species.allPokemons) {
+    for (const pokemon of SpeciesImpl.allPokemons) {
       if (
         pokemon.getName().toLowerCase() === name.toLowerCase() ||
         pokemon.getLocalizedName().toLowerCase() === name.toLowerCase()
@@ -976,7 +972,7 @@ export abstract class Species implements Comparable {
    * @returns {Species | null} The species that matches the given pokedex, or null if no such species exists.
    */
   public static getFromDex(dex: number | string): Species | null {
-    for (const species of Species.allPokemons) {
+    for (const species of SpeciesImpl.allPokemons) {
       if (
         (typeof dex === `number` &&
           species.getNationalPokedex().asNumber() === dex) ||

--- a/src/private/entity/SpeciesImpl.mts
+++ b/src/private/entity/SpeciesImpl.mts
@@ -1,5 +1,6 @@
 import i18next from 'i18next'
 import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { asserts } from 'io/github/sayakie/hakase/util/asserts.mjs'
 import { toStringHelper } from 'io/github/sayakie/hakase/util/function.mjs'
 
 export class SpeciesImpl extends Species {
@@ -20,11 +21,11 @@ export class SpeciesImpl extends Species {
   }
 
   public isLegendary(): boolean {
-    return Species.legendaries.some(legendary => legendary === this)
+    return Species.legendaries.has(this)
   }
 
   public isUltraBeast(): boolean {
-    return Species.ultrabeasts.some(ultrabeast => ultrabeast === this)
+    return Species.ultrabeasts.has(this)
   }
 
   public getName(): string {
@@ -73,7 +74,10 @@ export class SpeciesImpl extends Species {
   }
 
   static {
-    Species.legendaries.concat([
+    asserts<Set<Species>>(Species.legendaries)
+    asserts<Set<Species>>(Species.ultrabeasts)
+
+    const legendaries = [
       Species.MissingNo,
 
       /** Generation 1 */
@@ -158,9 +162,9 @@ export class SpeciesImpl extends Species {
       Species.Glastrier,
       Species.Spectrier,
       Species.Calyrex
-    ])
+    ]
 
-    Species.ultrabeasts.concat([
+    const ultrabests = [
       Species.Blacephalon,
       Species.Buzzwole,
       Species.Celesteela,
@@ -172,6 +176,9 @@ export class SpeciesImpl extends Species {
       Species.Kartana,
       Species.Stakataka,
       Species.Xurkitree
-    ])
+    ]
+
+    legendaries.forEach(Species.legendaries.add, Species.legendaries)
+    ultrabests.forEach(Species.ultrabeasts.add, Species.ultrabeasts)
   }
 }

--- a/src/private/entity/SpeciesImpl.mts
+++ b/src/private/entity/SpeciesImpl.mts
@@ -1,9 +1,12 @@
 import i18next from 'i18next'
 import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
-import { asserts } from 'io/github/sayakie/hakase/util/asserts.mjs'
 import { toStringHelper } from 'io/github/sayakie/hakase/util/function.mjs'
 
 export class SpeciesImpl extends Species {
+  public static readonly legendaries: Set<Species> = new Set()
+  public static readonly ultrabeasts: Set<Species> = new Set()
+  public static readonly allPokemons: Set<Species> = new Set()
+
   /**
    * Creates an EnumSpecies from the given dex number and name.
    *
@@ -21,11 +24,11 @@ export class SpeciesImpl extends Species {
   }
 
   public isLegendary(): boolean {
-    return Species.legendaries.has(this)
+    return SpeciesImpl.legendaries.has(this)
   }
 
   public isUltraBeast(): boolean {
-    return Species.ultrabeasts.has(this)
+    return SpeciesImpl.ultrabeasts.has(this)
   }
 
   public getName(): string {
@@ -74,9 +77,6 @@ export class SpeciesImpl extends Species {
   }
 
   static {
-    asserts<Set<Species>>(Species.legendaries)
-    asserts<Set<Species>>(Species.ultrabeasts)
-
     const legendaries = [
       Species.MissingNo,
 
@@ -178,7 +178,7 @@ export class SpeciesImpl extends Species {
       Species.Xurkitree
     ]
 
-    legendaries.forEach(Species.legendaries.add, Species.legendaries)
-    ultrabests.forEach(Species.ultrabeasts.add, Species.ultrabeasts)
+    legendaries.forEach(SpeciesImpl.legendaries.add, SpeciesImpl.legendaries)
+    ultrabests.forEach(SpeciesImpl.ultrabeasts.add, SpeciesImpl.ultrabeasts)
   }
 }


### PR DESCRIPTION
In the SpeciesImpl file, we make an mistake which static fields like "Species.legendaries" and "Species.ultrabeasts" are just concatenated with the species name but it is not set to the origin fields. This pr closes #25 