### PR TITLE
Implement variant pokemon forms

### DIFF
--- a/src/Constant.mts
+++ b/src/Constant.mts
@@ -33,10 +33,16 @@ export const ClientStatus = createEnum(
   toUpperCase(['Initializing', 'Initialized', 'Ready', 'Deferred', 'Destroyed'])
 )
 
-export const enum FormFlags {
-  ExposeMeta = 0x1,
-  FakeForm = 0x2,
-  PinToPrefix = 0x4
+export const enum FormFlag {
+  DefaultForm = 0x1,
+  AlterForm = 0x2,
+  UnreleasedForm = 0x4,
+  GenderlessForm = 0x8,
+  GenderForm = 0x10,
+  MegaForm = 0x20,
+  AlolanForm = 0x40,
+  GalarianForm = 0x80,
+  HisuianForm = 0x100,
+  UnownForm = 0x200,
+  DisplayFormName = 0x400
 }
-
-// export const FormFlag = keyMirror(['ExposeMeta', 'FakeForm', 'PinToPrefix'])

--- a/src/entity/FormBelongToSpecies.mts
+++ b/src/entity/FormBelongToSpecies.mts
@@ -1,9 +1,11 @@
 import type { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import {
+  FormBelongToSpeciesBuilderImpl,
+  FormBelongToSpeciesImpl
+} from 'io/github/sayakie/hakase/private/entity/FormBelongToSpeciesImpl.mjs'
 import type { Cloneable } from 'io/github/sayakie/hakase/util/Cloneable.mjs'
 import type { Comparable } from 'io/github/sayakie/hakase/util/Comparable.mjs'
 import type { ResettableBuilder } from 'io/github/sayakie/hakase/util/ResettableBuilder.mjs'
-
-import { FormBelongToSpeciesImpl } from '../private/entity/FormBelongToSpeciesImpl.mjs'
 
 export interface FormBelongToSpeciesBuilder
   extends ResettableBuilder<FormBelongToSpecies, FormBelongToSpeciesBuilder> {
@@ -65,6 +67,10 @@ export abstract class FormBelongToSpecies
   public abstract readonly species: Species
   public abstract readonly form: number
   public abstract readonly flags: number
+
+  public static builder(): FormBelongToSpeciesBuilder {
+    return new FormBelongToSpeciesBuilderImpl()
+  }
 
   public abstract builder(): FormBelongToSpeciesBuilder
 

--- a/src/entity/FormBelongToSpecies.mts
+++ b/src/entity/FormBelongToSpecies.mts
@@ -9,11 +9,51 @@ import type { ResettableBuilder } from 'io/github/sayakie/hakase/util/Resettable
 
 export interface FormBelongToSpeciesBuilder
   extends ResettableBuilder<FormBelongToSpecies, FormBelongToSpeciesBuilder> {
+  /**
+   * Sets the species of this form.
+   *
+   * @param {Species} species The species of this form
+   * @returns {this} This builder, for chaining
+   */
   species(species: Species): this
+
+  /**
+   * Sets the form integer of this form.
+   *
+   * @param {number} form The form integer of this form
+   * @returns {this} This builder, for chaining
+   */
   form(form: number): this
+
+  /**
+   * Sets the flags of this form.
+   *
+   * @param {...number} flags The flags of this form
+   * @returns {this} This builder, for chaining
+   */
   flags(...flags: number[]): this
+
+  /**
+   * Sets the sprite suffix of this form.
+   *
+   * @param {string} spriteSuffix The sprite suffix of this form
+   * @returns {this} This builder, for chaining
+   */
   spriteSuffix(spriteSuffix: string): this
+
+  /**
+   * Sets the image suffix of this form.
+   *
+   * @param {string} imageSuffix The image suffix of this form
+   * @returns {this} This builder, for chaining
+   */
   imageSuffix(imageSuffix: string): this
+
+  /**
+   * Builds the {@link FormBelongToSpecies} from the values in this builder.
+   *
+   * @returns {FormBelongToSpecies} The FormBelongToSpecies
+   */
   build(): FormBelongToSpecies
 }
 

--- a/src/entity/FormBelongToSpecies.mts
+++ b/src/entity/FormBelongToSpecies.mts
@@ -118,6 +118,12 @@ export abstract class FormBelongToSpecies
 
   public abstract builder(): FormBelongToSpeciesBuilder
 
+  public abstract isDefaultForm(): boolean
+  public abstract isMegaForm(): boolean
+  public abstract isAlolan(): boolean
+  public abstract isGalarian(): boolean
+  public abstract isHisuian(): boolean
+
   public abstract equals(other: any): boolean
   public abstract clone(): FormBelongToSpecies
 }

--- a/src/entity/FormBelongToSpecies.mts
+++ b/src/entity/FormBelongToSpecies.mts
@@ -36,18 +36,18 @@ export interface FormBelongToSpeciesBuilder
   /**
    * Sets the sprite suffix of this form.
    *
-   * @param {string} spriteSuffix The sprite suffix of this form
+   * @param {?string | null} [spriteSuffix] The sprite suffix of this form
    * @returns {this} This builder, for chaining
    */
-  spriteSuffix(spriteSuffix: string): this
+  spriteSuffix(spriteSuffix?: string): this
 
   /**
    * Sets the image suffix of this form.
    *
-   * @param {string} imageSuffix The image suffix of this form
+   * @param {?string | null} [imageSuffix] The image suffix of this form
    * @returns {this} This builder, for chaining
    */
-  imageSuffix(imageSuffix: string): this
+  imageSuffix(imageSuffix?: string): this
 
   /**
    * Builds the {@link FormBelongToSpecies} from the values in this builder.

--- a/src/entity/FormBelongToSpecies.mts
+++ b/src/entity/FormBelongToSpecies.mts
@@ -12,6 +12,8 @@ export interface FormBelongToSpeciesBuilder
   species(species: Species): this
   form(form: number): this
   flags(...flags: number[]): this
+  spriteSuffix(spriteSuffix: string): this
+  imageSuffix(imageSuffix: string): this
   build(): FormBelongToSpecies
 }
 
@@ -67,6 +69,8 @@ export abstract class FormBelongToSpecies
   public abstract readonly species: Species
   public abstract readonly form: number
   public abstract readonly flags: number
+  public abstract readonly spriteSuffix: string | null
+  public abstract readonly imageSuffix: string | null
 
   public static builder(): FormBelongToSpeciesBuilder {
     return new FormBelongToSpeciesBuilderImpl()

--- a/src/entity/FormBelongToSpecies.mts
+++ b/src/entity/FormBelongToSpecies.mts
@@ -63,7 +63,7 @@ export abstract class FormBelongToSpecies
   /**
    * Collection of all species whom legacy normal forms exist for.
    */
-  public static readonly normalForms: ReadonlySet<Species> = new Set()
+  public static readonly customNormalForms: ReadonlySet<Species> = new Set()
 
   /**
    * Collection of all species whom have mega evolution forms.

--- a/src/entity/Species.mts
+++ b/src/entity/Species.mts
@@ -901,7 +901,7 @@ export abstract class Species implements Comparable {
   public static readonly Glastrier = SpeciesImpl.of(896, 'Glastrier')
   public static readonly Spectrier = SpeciesImpl.of(897, 'Spectrier')
   public static readonly Calyrex = SpeciesImpl.of(898, 'Calyrex')
-  public static readonly Wyrdeer = SpeciesImpl.of(899, 'Wyrdeer ')
+  public static readonly Wyrdeer = SpeciesImpl.of(899, 'Wyrdeer')
 
   protected constructor(
     protected readonly dex: number,

--- a/src/entity/form/.eslintrc.cjs
+++ b/src/entity/form/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  "extends": "../../../.eslintrc.cjs",
+  "rules": {
+    '@typescript-eslint/naming-convention': [0],
+    'sort-keys-fix/sort-keys-fix': [0]
+  }
+}

--- a/src/entity/form/EnumAegislash.mts
+++ b/src/entity/form/EnumAegislash.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Aegislash.
+ */
+export const EnumAegislash = {
+  Shield: FormBelongToSpecies.builder()
+    .species(Species.Aegislash)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-shield`)
+    .build(),
+
+  Blade: FormBelongToSpecies.builder()
+    .species(Species.Aegislash)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-blade`)
+    .build(),
+
+  /**
+   * Returns all forms of Aegislash.
+   * @returns {FormBelongToSpecies[]} All forms of Aegislash.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumAegislash.Shield, EnumAegislash.Blade]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Shield` | `Blade` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `shield`:
+        return EnumAegislash.Shield
+      case `blade`:
+        return EnumAegislash.Blade
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumAlcremie.mts
+++ b/src/entity/form/EnumAlcremie.mts
@@ -1,0 +1,691 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Alcremie.
+ */
+export const EnumAlcremie = {
+  StrawBerry: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-vanilla')
+    .imageSuffix('-vanilla-cream-strawberry')
+    .build(),
+  StrawBerryRubyCream: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-rubycream')
+    .imageSuffix('-ruby-cream-strawberry')
+    .build(),
+  StrawBerryMatcha: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-matcha')
+    .imageSuffix('-matcha-cream-strawberry')
+    .build(),
+  StrawBerryMint: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-mint')
+    .imageSuffix('-mint-cream-strawberry')
+    .build(),
+  StrawBerryLemon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(4)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-lemon')
+    .imageSuffix('-lemon-cream-strawberry')
+    .build(),
+  StrawBerrySalted: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(5)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-salted')
+    .imageSuffix('-salted-cream-strawberry')
+    .build(),
+  StrawBerryRubySwirl: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(6)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-rubyswirl')
+    .imageSuffix('-ruby-swirl-strawberry')
+    .build(),
+  StrawBerryCaramel: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(7)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-caramel')
+    .imageSuffix('-caramel-swirl-strawberry')
+    .build(),
+  StrawBerryRainbow: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(8)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-strawberry-rainbow')
+    .imageSuffix('-rainbow-swirl-strawberry')
+    .build(),
+
+  Berry: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(9)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-vanilla')
+    .imageSuffix('-vanilla-cream-berry')
+    .build(),
+  BerryRubyCream: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(10)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-rubycream')
+    .imageSuffix('-ruby-cream-berry')
+    .build(),
+  BerryMatcha: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(11)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-matcha')
+    .imageSuffix('-matcha-cream-berry')
+    .build(),
+  BerryMint: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(12)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-mint')
+    .imageSuffix('-mint-cream-berry')
+    .build(),
+  BerryLemon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(13)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-lemon')
+    .imageSuffix('-lemon-cream-berry')
+    .build(),
+  BerrySalted: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(14)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-salted')
+    .imageSuffix('-salted-cream-berry')
+    .build(),
+  BerryRubySwirl: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(15)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-rubyswirl')
+    .imageSuffix('-ruby-swirl-berry')
+    .build(),
+  BerryCaramel: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(16)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-caramel')
+    .imageSuffix('-caramel-swirl-berry')
+    .build(),
+  BerryRainbow: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(17)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-berry-rainbow')
+    .imageSuffix('-rainbow-swirl-berry')
+    .build(),
+
+  Love: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(18)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-vanilla')
+    .imageSuffix('-vanilla-cream-love')
+    .build(),
+  LoveRubyCream: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(19)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-rubycream')
+    .imageSuffix('-ruby-cream-love')
+    .build(),
+  LoveMatcha: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(20)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-matcha')
+    .imageSuffix('-matcha-cream-love')
+    .build(),
+  LoveMint: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(21)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-mint')
+    .imageSuffix('-mint-cream-love')
+    .build(),
+  LoveLemon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(22)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-lemon')
+    .imageSuffix('-lemon-cream-love')
+    .build(),
+  LoveSalted: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(23)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-salted')
+    .imageSuffix('-salted-cream-love')
+    .build(),
+  LoveRubySwirl: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(24)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-rubyswirl')
+    .imageSuffix('-ruby-swirl-love')
+    .build(),
+  LoveCaramel: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(25)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-caramel')
+    .imageSuffix('-caramel-swirl-love')
+    .build(),
+  LoveRainbow: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(26)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-love-rainbow')
+    .imageSuffix('-rainbow-swirl-love')
+    .build(),
+
+  Star: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(27)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-vanilla')
+    .imageSuffix('-vanilla-cream-star')
+    .build(),
+  StarRubyCream: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(28)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-rubycream')
+    .imageSuffix('-ruby-cream-star')
+    .build(),
+  StarMatcha: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(29)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-matcha')
+    .imageSuffix('-matcha-cream-star')
+    .build(),
+  StarMint: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(30)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-mint')
+    .imageSuffix('-mint-cream-star')
+    .build(),
+  StarLemon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(31)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-lemon')
+    .imageSuffix('-lemon-cream-star')
+    .build(),
+  StarSalted: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(32)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-salted')
+    .imageSuffix('-salted-cream-star')
+    .build(),
+  StarRubySwirl: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(33)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-rubyswirl')
+    .imageSuffix('-ruby-swirl-star')
+    .build(),
+  StarCaramel: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(34)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-caramel')
+    .imageSuffix('-caramel-swirl-star')
+    .build(),
+  StarRainbow: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(35)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-star-rainbow')
+    .imageSuffix('-rainbow-swirl-star')
+    .build(),
+
+  Clover: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(36)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-vanilla')
+    .imageSuffix('-vanilla-cream-clover')
+    .build(),
+  CloverRubyCream: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(37)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-rubycream')
+    .imageSuffix('-ruby-cream-clover')
+    .build(),
+  CloverMatcha: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(38)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-matcha')
+    .imageSuffix('-matcha-cream-clover')
+    .build(),
+  CloverMint: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(39)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-mint')
+    .imageSuffix('-mint-cream-clover')
+    .build(),
+  CloverLemon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(40)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-lemon')
+    .imageSuffix('-lemon-cream-clover')
+    .build(),
+  CloverSalted: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(41)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-salted')
+    .imageSuffix('-salted-cream-clover')
+    .build(),
+  CloverRubySwirl: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(42)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-rubyswirl')
+    .imageSuffix('-ruby-swirl-clover')
+    .build(),
+  CloverCaramel: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(43)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-caramel')
+    .imageSuffix('-caramel-swirl-clover')
+    .build(),
+  CloverRainbow: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(44)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-clover-rainbow')
+    .imageSuffix('-rainbow-swirl-clover')
+    .build(),
+
+  Flower: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(45)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-vanilla')
+    .imageSuffix('-vanilla-cream-flower')
+    .build(),
+  FlowerRubyCream: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(46)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-rubycream')
+    .imageSuffix('-ruby-cream-flower')
+    .build(),
+  FlowerMatcha: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(47)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-matcha')
+    .imageSuffix('-matcha-cream-flower')
+    .build(),
+  FlowerMint: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(48)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-mint')
+    .imageSuffix('-mint-cream-flower')
+    .build(),
+  FlowerLemon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(49)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-lemon')
+    .imageSuffix('-lemon-cream-flower')
+    .build(),
+  FlowerSalted: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(50)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-salted')
+    .imageSuffix('-salted-cream-flower')
+    .build(),
+  FlowerRubySwirl: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(51)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-rubyswirl')
+    .imageSuffix('-ruby-swirl-flower')
+    .build(),
+  FlowerCaramel: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(52)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-caramel')
+    .imageSuffix('-caramel-swirl-flower')
+    .build(),
+  FlowerRainbow: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(53)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-flower-rainbow')
+    .imageSuffix('-rainbow-swirl-flower')
+    .build(),
+
+  Ribbon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(54)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-vanilla')
+    .imageSuffix('-vanilla-cream-ribbon')
+    .build(),
+  RibbonRubyCream: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(55)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-rubycream')
+    .imageSuffix('-ruby-cream-ribbon')
+    .build(),
+  RibbonMatcha: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(56)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-matcha')
+    .imageSuffix('-matcha-cream-ribbon')
+    .build(),
+  RibbonMint: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(57)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-mint')
+    .imageSuffix('-mint-cream-ribbon')
+    .build(),
+  RibbonLemon: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(58)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-lemon')
+    .imageSuffix('-lemon-cream-ribbon')
+    .build(),
+  RibbonSalted: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(59)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-salted')
+    .imageSuffix('-salted-cream-ribbon')
+    .build(),
+  RibbonRubySwirl: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(60)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-rubyswirl')
+    .imageSuffix('-ruby-swirl-ribbon')
+    .build(),
+  RibbonCaramel: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(61)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-caramel')
+    .imageSuffix('-caramel-swirl-ribbon')
+    .build(),
+  RibbonRainbow: FormBelongToSpecies.builder()
+    .species(Species.Alcremie)
+    .form(62)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix('-ribbon-rainbow')
+    .imageSuffix('-rainbow-swirl-ribbon')
+    .build(),
+
+  /**
+   * Returns all forms of Alcremie.
+   * @returns {FormBelongToSpecies[]} All forms of Alcremie.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumAlcremie.StrawBerry,
+      EnumAlcremie.StrawBerryRubyCream,
+      EnumAlcremie.StrawBerryMatcha,
+      EnumAlcremie.StrawBerryMint,
+      EnumAlcremie.StrawBerryLemon,
+      EnumAlcremie.StrawBerrySalted,
+      EnumAlcremie.StrawBerryRubySwirl,
+      EnumAlcremie.StrawBerryCaramel,
+      EnumAlcremie.StrawBerryRainbow,
+
+      EnumAlcremie.Berry,
+      EnumAlcremie.BerryRubyCream,
+      EnumAlcremie.BerryMatcha,
+      EnumAlcremie.BerryMint,
+      EnumAlcremie.BerryLemon,
+      EnumAlcremie.BerrySalted,
+      EnumAlcremie.BerryRubySwirl,
+      EnumAlcremie.BerryCaramel,
+      EnumAlcremie.BerryRainbow,
+
+      EnumAlcremie.Love,
+      EnumAlcremie.LoveRubyCream,
+      EnumAlcremie.LoveMatcha,
+      EnumAlcremie.LoveMint,
+      EnumAlcremie.LoveLemon,
+      EnumAlcremie.LoveSalted,
+      EnumAlcremie.LoveRubySwirl,
+      EnumAlcremie.LoveCaramel,
+      EnumAlcremie.LoveRainbow,
+
+      EnumAlcremie.Clover,
+      EnumAlcremie.CloverRubyCream,
+      EnumAlcremie.CloverMatcha,
+      EnumAlcremie.CloverMint,
+      EnumAlcremie.CloverLemon,
+      EnumAlcremie.CloverSalted,
+      EnumAlcremie.CloverRubySwirl,
+      EnumAlcremie.CloverCaramel,
+      EnumAlcremie.CloverRainbow,
+
+      EnumAlcremie.Flower,
+      EnumAlcremie.FlowerRubyCream,
+      EnumAlcremie.FlowerMatcha,
+      EnumAlcremie.FlowerMint,
+      EnumAlcremie.FlowerLemon,
+      EnumAlcremie.FlowerSalted,
+      EnumAlcremie.FlowerRubySwirl,
+      EnumAlcremie.FlowerCaramel,
+      EnumAlcremie.FlowerRainbow,
+
+      EnumAlcremie.Ribbon,
+      EnumAlcremie.RibbonRubyCream,
+      EnumAlcremie.RibbonMatcha,
+      EnumAlcremie.RibbonMint,
+      EnumAlcremie.RibbonLemon,
+      EnumAlcremie.RibbonSalted,
+      EnumAlcremie.RibbonRubySwirl,
+      EnumAlcremie.RibbonCaramel,
+      EnumAlcremie.RibbonRainbow
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value:
+      | 'StrawBerry'
+      | 'StrawBerryRubyCream'
+      | 'StrawBerryMatcha'
+      | 'StrawBerryMint'
+      | 'StrawBerryLemon'
+      | 'StrawBerrySalted'
+      | 'StrawBerryRubySwirl'
+      | 'StrawBerryCaramel'
+      | 'StrawBerryRainbow'
+      | 'Berry'
+      | 'BerryRubyCream'
+      | 'BerryMatcha'
+      | 'BerryMint'
+      | 'BerryLemon'
+      | 'BerrySalted'
+      | 'BerryRubySwirl'
+      | 'BerryCaramel'
+      | 'BerryRainbow'
+      | 'Love'
+      | 'LoveRubyCream'
+      | 'LoveMatcha'
+      | 'LoveMint'
+      | 'LoveLemon'
+      | 'LoveSalted'
+      | 'LoveRubySwirl'
+      | 'LoveCaramel'
+      | 'LoveRainbow'
+      | 'Clover'
+      | 'CloverRubyCream'
+      | 'CloverMatcha'
+      | 'CloverMint'
+      | 'CloverLemon'
+      | 'CloverSalted'
+      | 'CloverRubySwirl'
+      | 'CloverCaramel'
+      | 'CloverRainbow'
+      | 'Flower'
+      | 'FlowerRubyCream'
+      | 'FlowerMatcha'
+      | 'FlowerMint'
+      | 'FlowerLemon'
+      | 'FlowerSalted'
+      | 'FlowerRubySwirl'
+      | 'FlowerCaramel'
+      | 'FlowerRainbow'
+      | 'Ribbon'
+      | 'RibbonRubyCream'
+      | 'RibbonMatcha'
+      | 'RibbonMint'
+      | 'RibbonLemon'
+      | 'RibbonSalted'
+      | 'RibbonRubySwirl'
+      | 'RibbonCaramel'
+      | 'RibbonRainbow'
+      | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `strawberry`:
+        return EnumAlcremie.StrawBerry
+      case `strawberryrubycream`:
+        return EnumAlcremie.StrawBerryRubyCream
+      case `strawberrymatcha`:
+        return EnumAlcremie.StrawBerryMatcha
+      case `strawberrymint`:
+        return EnumAlcremie.StrawBerryMint
+      case `strawberrylemon`:
+        return EnumAlcremie.StrawBerryLemon
+      case `strawberrysalted`:
+        return EnumAlcremie.StrawBerrySalted
+      case `strawberryrubyswirl`:
+        return EnumAlcremie.StrawBerryRubySwirl
+      case `strawberrycaramel`:
+        return EnumAlcremie.StrawBerryCaramel
+      case `strawberryrainbow`:
+        return EnumAlcremie.StrawBerryRainbow
+
+      case `berry`:
+        return EnumAlcremie.Berry
+      case `berryrubycream`:
+        return EnumAlcremie.BerryRubyCream
+      case `berrymatcha`:
+        return EnumAlcremie.BerryMatcha
+      case `berrymint`:
+        return EnumAlcremie.BerryMint
+      case `berrylemon`:
+        return EnumAlcremie.BerryLemon
+      case `berrysalted`:
+        return EnumAlcremie.BerrySalted
+      case `berryrubyswirl`:
+        return EnumAlcremie.BerryRubySwirl
+      case `berrycaramel`:
+        return EnumAlcremie.BerryCaramel
+      case `berryrainbow`:
+        return EnumAlcremie.BerryRainbow
+
+      case `love`:
+        return EnumAlcremie.Love
+      case `loverubycream`:
+        return EnumAlcremie.LoveRubyCream
+      case `lovematcha`:
+        return EnumAlcremie.LoveMatcha
+      case `lovemint`:
+        return EnumAlcremie.LoveMint
+      case `lovelemon`:
+        return EnumAlcremie.LoveLemon
+      case `lovesalted`:
+        return EnumAlcremie.LoveSalted
+      case `loverubyswirl`:
+        return EnumAlcremie.LoveRubySwirl
+      case `lovecaramel`:
+        return EnumAlcremie.LoveCaramel
+      case `loverainbow`:
+        return EnumAlcremie.LoveRainbow
+
+      case `flower`:
+        return EnumAlcremie.Flower
+      case `flowerrubycream`:
+        return EnumAlcremie.FlowerRubyCream
+      case `flowermatcha`:
+        return EnumAlcremie.FlowerMatcha
+      case `flowermint`:
+        return EnumAlcremie.FlowerMint
+      case `flowerlemon`:
+        return EnumAlcremie.FlowerLemon
+      case `flowersalted`:
+        return EnumAlcremie.FlowerSalted
+      case `flowerrubyswirl`:
+        return EnumAlcremie.FlowerRubySwirl
+      case `flowercaramel`:
+        return EnumAlcremie.FlowerCaramel
+      case `flowerrainbow`:
+        return EnumAlcremie.FlowerRainbow
+
+      case `ribbon`:
+        return EnumAlcremie.Ribbon
+      case `ribbonrubycream`:
+        return EnumAlcremie.RibbonRubyCream
+      case `ribbonmatcha`:
+        return EnumAlcremie.RibbonMatcha
+      case `ribbonmint`:
+        return EnumAlcremie.RibbonMint
+      case `ribbonlemon`:
+        return EnumAlcremie.RibbonLemon
+      case `ribbonsalted`:
+        return EnumAlcremie.RibbonSalted
+      case `ribbonrubyswirl`:
+        return EnumAlcremie.RibbonRubySwirl
+      case `ribboncaramel`:
+        return EnumAlcremie.RibbonCaramel
+      case `ribbonrainbow`:
+        return EnumAlcremie.RibbonRainbow
+
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumArceus.mts
+++ b/src/entity/form/EnumArceus.mts
@@ -1,0 +1,206 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Arceus.
+ */
+export const EnumArceus = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .build(),
+
+  Grass: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(1)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Fire: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(2)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Water: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(3)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Flying: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(4)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Bug: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(5)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Poison: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(6)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Electric: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(7)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Psychic: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(8)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Rock: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(9)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Ground: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(10)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Dark: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(11)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Ghost: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(12)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Steel: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(13)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Fighting: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(14)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Dragon: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(15)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  Fairy: FormBelongToSpecies.builder()
+    .species(Species.Arceus)
+    .form(16)
+    .flags(FormFlag.AlterForm)
+    .build(),
+
+  /**
+   * Returns all forms of Arceus.
+   * @returns {FormBelongToSpecies[]} All forms of Arceus.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumArceus.Normal,
+      EnumArceus.Grass,
+      EnumArceus.Fire,
+      EnumArceus.Water,
+      EnumArceus.Flying,
+      EnumArceus.Bug,
+      EnumArceus.Poison,
+      EnumArceus.Electric,
+      EnumArceus.Psychic,
+      EnumArceus.Rock,
+      EnumArceus.Ground,
+      EnumArceus.Dark,
+      EnumArceus.Ghost,
+      EnumArceus.Steel,
+      EnumArceus.Fighting,
+      EnumArceus.Dragon,
+      EnumArceus.Fairy
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value:
+      | `Normal`
+      | `Grass`
+      | `Fire`
+      | `Water`
+      | `Flying`
+      | `Bug`
+      | `Poison`
+      | `Electric`
+      | `Psychic`
+      | `Rock`
+      | `Ground`
+      | `Dark`
+      | `Ghost`
+      | `Steel`
+      | `Fighting`
+      | `Dragon`
+      | `Fairy`
+  ): FormBelongToSpecies {
+    switch (value.toLowerCase()) {
+      case `normal`:
+        return EnumArceus.Normal
+      case `grass`:
+        return EnumArceus.Grass
+      case `fire`:
+        return EnumArceus.Fire
+      case `water`:
+        return EnumArceus.Water
+      case `flying`:
+        return EnumArceus.Flying
+      case `bug`:
+        return EnumArceus.Bug
+      case `poison`:
+        return EnumArceus.Poison
+      case `electric`:
+        return EnumArceus.Electric
+      case `psychic`:
+        return EnumArceus.Psychic
+      case `rock`:
+        return EnumArceus.Rock
+      case `ground`:
+        return EnumArceus.Ground
+      case `dark`:
+        return EnumArceus.Dark
+      case `ghost`:
+        return EnumArceus.Ghost
+      case `steel`:
+        return EnumArceus.Steel
+      case `fighting`:
+        return EnumArceus.Fighting
+      case `dragon`:
+        return EnumArceus.Dragon
+      case `fairy`:
+        return EnumArceus.Fairy
+      default:
+        throw new IllegalArgumentException(
+          `The given name '${value}' is not a member of EnumArceus.`
+        )
+    }
+  }
+} as const

--- a/src/entity/form/EnumBasculin.mts
+++ b/src/entity/form/EnumBasculin.mts
@@ -1,0 +1,51 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Basculin.
+ */
+export const EnumBasculin = {
+  Red: FormBelongToSpecies.builder()
+    .species(Species.Basculin)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-red`)
+    .imageSuffix(`-red-striped`)
+    .build(),
+
+  Blue: FormBelongToSpecies.builder()
+    .species(Species.Basculin)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-blue`)
+    .imageSuffix(`-blue-striped`)
+    .build(),
+
+  /**
+   * Returns all forms of Basculin.
+   * @returns {FormBelongToSpecies[]} All forms of Basculin.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumBasculin.Red, EnumBasculin.Blue]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Red` | `Blue` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `red`:
+        return EnumBasculin.Red
+      case `blue`:
+        return EnumBasculin.Blue
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumBurmy.mts
+++ b/src/entity/form/EnumBurmy.mts
@@ -16,13 +16,13 @@ export const EnumBurmy = {
   Sandy: FormBelongToSpecies.builder()
     .species(Species.Burmy)
     .form(1)
-    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
     .spriteSuffix(`-sandy`)
     .build(),
   Trash: FormBelongToSpecies.builder()
     .species(Species.Burmy)
     .form(2)
-    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
     .spriteSuffix(`-trash`)
     .build(),
 

--- a/src/entity/form/EnumBurmy.mts
+++ b/src/entity/form/EnumBurmy.mts
@@ -1,0 +1,56 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Burmy.
+ */
+export const EnumBurmy = {
+  Plant: FormBelongToSpecies.builder()
+    .species(Species.Burmy)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-plant`)
+    .build(),
+  Sandy: FormBelongToSpecies.builder()
+    .species(Species.Burmy)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-sandy`)
+    .build(),
+  Trash: FormBelongToSpecies.builder()
+    .species(Species.Burmy)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-trash`)
+    .build(),
+
+  /**
+   * Returns all forms of Burmy.
+   * @returns {FormBelongToSpecies[]} All forms of Burmy.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumBurmy.Plant, EnumBurmy.Sandy, EnumBurmy.Trash]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Plant` | `Sandy` | `Trash` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `plant`:
+        return EnumBurmy.Plant
+      case `sandy`:
+        return EnumBurmy.Sandy
+      case `trash`:
+        return EnumBurmy.Trash
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumCalyrex.mts
+++ b/src/entity/form/EnumCalyrex.mts
@@ -1,0 +1,65 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Calyrex.
+ */
+export const EnumCalyrex = {
+  Ordinary: FormBelongToSpecies.builder()
+    .species(Species.Calyrex)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-ordinary`)
+    .imageSuffix(``)
+    .build(),
+
+  IceRider: FormBelongToSpecies.builder()
+    .species(Species.Calyrex)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-icerider`)
+    .imageSuffix(`-ice-rider`)
+    .build(),
+
+  ShadowRider: FormBelongToSpecies.builder()
+    .species(Species.Calyrex)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-shadowrider`)
+    .imageSuffix(`-shadow-rider`)
+    .build(),
+
+  /**
+   * Returns all forms of Calyrex.
+   * @returns {FormBelongToSpecies[]} All forms of Calyrex.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumCalyrex.Ordinary, EnumCalyrex.IceRider, EnumCalyrex.ShadowRider]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Ordinary` | `IceRider` | `ShadowRider` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `ordinary`:
+        return EnumCalyrex.Ordinary
+      case `icerider`:
+      case `ice-rider`:
+        return EnumCalyrex.IceRider
+      case `shadowrider`:
+      case `shadow-rider`:
+        return EnumCalyrex.ShadowRider
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumCastform.mts
+++ b/src/entity/form/EnumCastform.mts
@@ -1,0 +1,81 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Castform.
+ */
+export const EnumCastform = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.Castform)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-normal`)
+    .imageSuffix(``)
+    .build(),
+
+  Ice: FormBelongToSpecies.builder()
+    .species(Species.Castform)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-ice`)
+    .imageSuffix(`-snowy`)
+    .build(),
+
+  Rain: FormBelongToSpecies.builder()
+    .species(Species.Castform)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-rain`)
+    .imageSuffix(`-rainy`)
+    .build(),
+
+  Sun: FormBelongToSpecies.builder()
+    .species(Species.Castform)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-sun`)
+    .imageSuffix(`-sunny`)
+    .build(),
+
+  /**
+   * Returns all forms of Castform.
+   * @returns {FormBelongToSpecies[]} All forms of Castform.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumCastform.Normal,
+      EnumCastform.Ice,
+      EnumCastform.Rain,
+      EnumCastform.Sun
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Normal` | `Ice` | `Rain` | `Sun` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `normal`:
+        return EnumCastform.Normal
+      case `ice`:
+      case `snowy`:
+        return EnumCastform.Ice
+      case `rain`:
+      case `rainy`:
+        return EnumCastform.Rain
+      case `sun`:
+      case `sunny`:
+        return EnumCastform.Sun
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumCherrim.mts
+++ b/src/entity/form/EnumCherrim.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Cherrim.
+ */
+export const EnumCherrim = {
+  Overcast: FormBelongToSpecies.builder()
+    .species(Species.Cherrim)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-overcast`)
+    .build(),
+
+  Sunshine: FormBelongToSpecies.builder()
+    .species(Species.Cherrim)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-sunshine`)
+    .build(),
+
+  /**
+   * Returns all forms of Cherrim.
+   * @returns {FormBelongToSpecies[]} All forms of Cherrim.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumCherrim.Overcast, EnumCherrim.Sunshine]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Overcast` | `Sunshine` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `overcast`:
+        return EnumCherrim.Overcast
+      case `sunshine`:
+        return EnumCherrim.Sunshine
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumDarmanitan.mts
+++ b/src/entity/form/EnumDarmanitan.mts
@@ -1,0 +1,78 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Darmanitan.
+ */
+export const EnumDarmanitan = {
+  Standard: FormBelongToSpecies.builder()
+    .species(Species.Darmanitan)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-normal`)
+    .build(),
+
+  Zen: FormBelongToSpecies.builder()
+    .species(Species.Darmanitan)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-zen`)
+    .build(),
+
+  GalarStandard: FormBelongToSpecies.builder()
+    .species(Species.Darmanitan)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.GalarianForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-galar-standard`)
+    .imageSuffix(`-galarian-standard`)
+    .build(),
+
+  GalarZen: FormBelongToSpecies.builder()
+    .species(Species.Darmanitan)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.GalarianForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-galar-zen`)
+    .imageSuffix(`-galarian-zen`)
+    .build(),
+
+  /**
+   * Returns all forms of Darmanitan.
+   * @returns {FormBelongToSpecies[]} All forms of Darmanitan.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumDarmanitan.Standard,
+      EnumDarmanitan.Zen,
+      EnumDarmanitan.GalarStandard,
+      EnumDarmanitan.GalarZen
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Standard` | `Zen` | `GalarStandard` | `GalarZen` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `standard`:
+        return EnumDarmanitan.Standard
+      case `zen`:
+        return EnumDarmanitan.Zen
+      case `galarstandard`:
+      case `galar-standard`:
+        return EnumDarmanitan.GalarStandard
+      case `galarzen`:
+      case `galar-zen`:
+        return EnumDarmanitan.GalarZen
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumDeoxys.mts
+++ b/src/entity/form/EnumDeoxys.mts
@@ -1,0 +1,77 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Deoxys.
+ */
+export const EnumDeoxys = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.Deoxys)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-normal`)
+    .build(),
+
+  Attack: FormBelongToSpecies.builder()
+    .species(Species.Deoxys)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-attack`)
+    .build(),
+
+  Defense: FormBelongToSpecies.builder()
+    .species(Species.Deoxys)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-defense`)
+    .build(),
+
+  Speed: FormBelongToSpecies.builder()
+    .species(Species.Deoxys)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-speed`)
+    .build(),
+
+  /**
+   * Returns all forms of Deoxys.
+   * @returns {FormBelongToSpecies[]} All forms of Deoxys.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumDeoxys.Normal,
+      EnumDeoxys.Attack,
+      EnumDeoxys.Defense,
+      EnumDeoxys.Speed
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Normal` | `Attack` | `Defense` | `Speed` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `normal`:
+        return EnumDeoxys.Normal
+      case `attack`:
+      case `atk`:
+        return EnumDeoxys.Attack
+      case `defense`:
+      case `def`:
+        return EnumDeoxys.Defense
+      case `speed`:
+      case `spd`:
+        return EnumDeoxys.Speed
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumEiscue.mts
+++ b/src/entity/form/EnumEiscue.mts
@@ -1,0 +1,51 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Eiscue.
+ */
+export const EnumEiscue = {
+  IceFace: FormBelongToSpecies.builder()
+    .species(Species.Eiscue)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-ice_face`)
+    .imageSuffix(`-ice`)
+    .build(),
+
+  NoiceFace: FormBelongToSpecies.builder()
+    .species(Species.Eiscue)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-noice_face`)
+    .imageSuffix(`-noice`)
+    .build(),
+
+  /**
+   * Returns all forms of Eiscue.
+   * @returns {FormBelongToSpecies[]} All forms of Eiscue.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumEiscue.IceFace, EnumEiscue.NoiceFace]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Ice` | `Noice` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `ice`:
+        return EnumEiscue.IceFace
+      case `noice`:
+        return EnumEiscue.NoiceFace
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumEternatus.mts
+++ b/src/entity/form/EnumEternatus.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Eternatus.
+ */
+export const EnumEternatus = {
+  Ordinary: FormBelongToSpecies.builder()
+    .species(Species.Eternatus)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-ordinary`)
+    .build(),
+
+  Eternamax: FormBelongToSpecies.builder()
+    .species(Species.Eternatus)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-eternamax`)
+    .build(),
+
+  /**
+   * Returns all forms of Eternatus.
+   * @returns {FormBelongToSpecies[]} All forms of Eternatus.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumEternatus.Ordinary, EnumEternatus.Eternamax]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Ordinary` | `Eternamax` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `ordinary`:
+        return EnumEternatus.Ordinary
+      case `eternamax`:
+        return EnumEternatus.Eternamax
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumFlabebe.mts
+++ b/src/entity/form/EnumFlabebe.mts
@@ -1,0 +1,94 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Flabebe.
+ */
+export const EnumFlabebe = {
+  Red: FormBelongToSpecies.builder()
+    .species(Species.Flabebe)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-red`)
+    .build(),
+
+  Yellow: FormBelongToSpecies.builder()
+    .species(Species.Flabebe)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-yellow`)
+    .build(),
+
+  Orange: FormBelongToSpecies.builder()
+    .species(Species.Flabebe)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-orange`)
+    .build(),
+
+  Blue: FormBelongToSpecies.builder()
+    .species(Species.Flabebe)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-blue`)
+    .build(),
+
+  White: FormBelongToSpecies.builder()
+    .species(Species.Flabebe)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-white`)
+    .build(),
+
+  AZ: FormBelongToSpecies.builder()
+    .species(Species.Flabebe)
+    .form(5)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-az`)
+    .build(),
+
+  /**
+   * Returns all forms of Flabebe.
+   * @returns {FormBelongToSpecies[]} All forms of Flabebe.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumFlabebe.Red,
+      EnumFlabebe.Yellow,
+      EnumFlabebe.Orange,
+      EnumFlabebe.Blue,
+      EnumFlabebe.White,
+      EnumFlabebe.AZ
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Red` | `Yellow` | `Orange` | `Blue` | `White` | `AZ` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `red`:
+        return EnumFlabebe.Red
+      case `yellow`:
+        return EnumFlabebe.Yellow
+      case `orange`:
+        return EnumFlabebe.Orange
+      case `blue`:
+        return EnumFlabebe.Blue
+      case `white`:
+        return EnumFlabebe.White
+      case `az`:
+        return EnumFlabebe.AZ
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumGastrodon.mts
+++ b/src/entity/form/EnumGastrodon.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Gastrodon.
+ */
+export const EnumGastrodon = {
+  East: FormBelongToSpecies.builder()
+    .species(Species.Gastrodon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-east`)
+    .build(),
+
+  West: FormBelongToSpecies.builder()
+    .species(Species.Gastrodon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-west`)
+    .build(),
+
+  /**
+   * Returns all forms of Gastrodon.
+   * @returns {FormBelongToSpecies[]} All forms of Gastrodon.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumGastrodon.East, EnumGastrodon.West]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `East` | `West` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `east`:
+        return EnumGastrodon.East
+      case `west`:
+        return EnumGastrodon.West
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumGiratina.mts
+++ b/src/entity/form/EnumGiratina.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Giratina.
+ */
+export const EnumGiratina = {
+  Altered: FormBelongToSpecies.builder()
+    .species(Species.Giratina)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-altered`)
+    .build(),
+
+  Origin: FormBelongToSpecies.builder()
+    .species(Species.Giratina)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-origin`)
+    .build(),
+
+  /**
+   * Returns all forms of Giratina.
+   * @returns {FormBelongToSpecies[]} All forms of Giratina.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumGiratina.Altered, EnumGiratina.Origin]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Altered` | `Origin` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `altered`:
+        return EnumGiratina.Altered
+      case `origin`:
+        return EnumGiratina.Origin
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumGreninja.mts
+++ b/src/entity/form/EnumGreninja.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Greninja.
+ */
+export const EnumGreninja = {
+  Base: FormBelongToSpecies.builder()
+    .species(Species.Greninja)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .build(),
+
+  Ash: FormBelongToSpecies.builder()
+    .species(Species.Greninja)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-ash`)
+    .build(),
+
+  /**
+   * Returns all forms of Greninja.
+   * @returns {FormBelongToSpecies[]} All forms of Greninja.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumGreninja.Base, EnumGreninja.Ash]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Base` | `Ash` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `base`:
+      case `normal`:
+        return EnumGreninja.Base
+      case `ash`:
+        return EnumGreninja.Ash
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumGroudon.mts
+++ b/src/entity/form/EnumGroudon.mts
@@ -1,0 +1,39 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Groudon.
+ */
+export const EnumGroudon = {
+  Meta: FormBelongToSpecies.builder()
+    .species(Species.Groudon)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .build(),
+
+  /**
+   * Returns all forms of Groudon.
+   * @returns {FormBelongToSpecies[]} All forms of Groudon.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumGroudon.Meta]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Meta` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `meta`:
+        return EnumGroudon.Meta
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumHeroDuo.mts
+++ b/src/entity/form/EnumHeroDuo.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of HeroDuo.
+ */
+export const EnumHeroDuo = {
+  Hero: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-hero`)
+    .build(),
+
+  Crowned: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-crowned`)
+    .build(),
+
+  /**
+   * Returns all forms of HeroDuo.
+   * @returns {FormBelongToSpecies[]} All forms of HeroDuo.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumHeroDuo.Hero, EnumHeroDuo.Crowned]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Hero` | `Crowned` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `hero`:
+        return EnumHeroDuo.Hero
+      case `crowned`:
+        return EnumHeroDuo.Crowned
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumHoopa.mts
+++ b/src/entity/form/EnumHoopa.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Hoopa.
+ */
+export const EnumHoopa = {
+  Confined: FormBelongToSpecies.builder()
+    .species(Species.Hoopa)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-confined`)
+    .build(),
+
+  Unbound: FormBelongToSpecies.builder()
+    .species(Species.Hoopa)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-unbound`)
+    .build(),
+
+  /**
+   * Returns all forms of Hoopa.
+   * @returns {FormBelongToSpecies[]} All forms of Hoopa.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumHoopa.Confined, EnumHoopa.Unbound]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Confined` | `Unbound` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `confined`:
+        return EnumHoopa.Confined
+      case `unbound`:
+        return EnumHoopa.Unbound
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumKeldeo.mts
+++ b/src/entity/form/EnumKeldeo.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Keldeo.
+ */
+export const EnumKeldeo = {
+  Ordinary: FormBelongToSpecies.builder()
+    .species(Species.Keldeo)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-ordinary`)
+    .build(),
+
+  Resolute: FormBelongToSpecies.builder()
+    .species(Species.Keldeo)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-resolute`)
+    .build(),
+
+  /**
+   * Returns all forms of Keldeo.
+   * @returns {FormBelongToSpecies[]} All forms of Keldeo.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumKeldeo.Ordinary, EnumKeldeo.Resolute]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Ordinary` | `Resolute` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `ordinary`:
+        return EnumKeldeo.Ordinary
+      case `resolute`:
+        return EnumKeldeo.Resolute
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumKyurem.mts
+++ b/src/entity/form/EnumKyurem.mts
@@ -1,0 +1,59 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Kyurem.
+ */
+export const EnumKyurem = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.Kyurem)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-normal`)
+    .imageSuffix(``)
+    .build(),
+
+  Black: FormBelongToSpecies.builder()
+    .species(Species.Kyurem)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-black`)
+    .build(),
+
+  White: FormBelongToSpecies.builder()
+    .species(Species.Kyurem)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-white`)
+    .build(),
+
+  /**
+   * Returns all forms of Kyurem.
+   * @returns {FormBelongToSpecies[]} All forms of Kyurem.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumKyurem.Normal, EnumKyurem.Black, EnumKyurem.White]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Normal` | `Black` | `White` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `normal`:
+        return EnumKyurem.Normal
+      case `black`:
+        return EnumKyurem.Black
+      case `white`:
+        return EnumKyurem.White
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumLycanroc.mts
+++ b/src/entity/form/EnumLycanroc.mts
@@ -1,0 +1,60 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Lycanroc.
+ */
+export const EnumLycanroc = {
+  Midday: FormBelongToSpecies.builder()
+    .species(Species.Lycanroc)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-midday`)
+    .build(),
+
+  Midnight: FormBelongToSpecies.builder()
+    .species(Species.Lycanroc)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-midnight`)
+    .build(),
+
+  Dusk: FormBelongToSpecies.builder()
+    .species(Species.Lycanroc)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-dusk`)
+    .build(),
+
+  /**
+   * Returns all forms of Lycanroc.
+   * @returns {FormBelongToSpecies[]} All forms of Lycanroc.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumLycanroc.Midday, EnumLycanroc.Midnight, EnumLycanroc.Dusk]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Midday` | `Midnight` | `Dusk` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `midday`:
+      case `mid-day`:
+        return EnumLycanroc.Midday
+      case `midnight`:
+      case `mid-night`:
+        return EnumLycanroc.Midnight
+      case `dusk`:
+        return EnumLycanroc.Dusk
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumMagearna.mts
+++ b/src/entity/form/EnumMagearna.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Magearna.
+ */
+export const EnumMagearna = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.Magearna)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .build(),
+
+  Original: FormBelongToSpecies.builder()
+    .species(Species.Magearna)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-o`)
+    .imageSuffix(`-original`)
+    .build(),
+
+  /**
+   * Returns all forms of Magearna.
+   * @returns {FormBelongToSpecies[]} All forms of Magearna.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumMagearna.Normal, EnumMagearna.Original]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Normal` | `Original`): FormBelongToSpecies {
+    switch (value.toLowerCase()) {
+      case `normal`:
+        return EnumMagearna.Normal
+      case `original`:
+        return EnumMagearna.Original
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumMeloetta.mts
+++ b/src/entity/form/EnumMeloetta.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Meloetta.
+ */
+export const EnumMeloetta = {
+  Aria: FormBelongToSpecies.builder()
+    .species(Species.Meloetta)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-aria`)
+    .build(),
+
+  Pirouette: FormBelongToSpecies.builder()
+    .species(Species.Meloetta)
+    .form(1)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-pirouette`)
+    .build(),
+
+  /**
+   * Returns all forms of Meloetta.
+   * @returns {FormBelongToSpecies[]} All forms of Meloetta.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumMeloetta.Aria, EnumMeloetta.Pirouette]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Aria` | `Pirouette`): FormBelongToSpecies {
+    switch (value.toLowerCase()) {
+      case `aria`:
+        return EnumMeloetta.Aria
+      case `pirouette`:
+        return EnumMeloetta.Pirouette
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumMimikyu.mts
+++ b/src/entity/form/EnumMimikyu.mts
@@ -1,0 +1,48 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Mimikyu.
+ */
+export const EnumMimikyu = {
+  Disguised: FormBelongToSpecies.builder()
+    .species(Species.Mimikyu)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .build(),
+
+  Busted: FormBelongToSpecies.builder()
+    .species(Species.Mimikyu)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-busted`)
+    .build(),
+
+  /**
+   * Returns all forms of Mimikyu.
+   * @returns {FormBelongToSpecies[]} All forms of Mimikyu.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumMimikyu.Disguised, EnumMimikyu.Busted]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Disguised` | `Busted`): FormBelongToSpecies {
+    switch (value.toLowerCase()) {
+      case `disguised`:
+        return EnumMimikyu.Disguised
+      case `busted`:
+        return EnumMimikyu.Busted
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumMinior.mts
+++ b/src/entity/form/EnumMinior.mts
@@ -1,0 +1,130 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Minior.
+ */
+export const EnumMinior = {
+  Meteor: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(0)
+    .flags(FormFlag.AlterForm)
+    .spriteSuffix(`-meteor`)
+    .build(),
+
+  Red: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-red`)
+    .imageSuffix(`-red-core`)
+    .build(),
+
+  Orange: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-orange`)
+    .imageSuffix(`-orange-core`)
+    .build(),
+
+  Yellow: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-yellow`)
+    .imageSuffix(`-yellow-core`)
+    .build(),
+
+  Green: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-green`)
+    .imageSuffix(`-green-core`)
+    .build(),
+
+  Blue: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-blue`)
+    .imageSuffix(`-blue-core`)
+    .build(),
+
+  Indigo: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-indigo`)
+    .imageSuffix(`-indigo-core`)
+    .build(),
+
+  Violet: FormBelongToSpecies.builder()
+    .species(Species.Minior)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-violet`)
+    .imageSuffix(`-violet-core`)
+    .build(),
+
+  /**
+   * Returns all forms of Minior.
+   * @returns {FormBelongToSpecies[]} All forms of Minior.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumMinior.Meteor,
+      EnumMinior.Red,
+      EnumMinior.Orange,
+      EnumMinior.Yellow,
+      EnumMinior.Green,
+      EnumMinior.Blue,
+      EnumMinior.Indigo,
+      EnumMinior.Violet
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value:
+      | `Meteor`
+      | `Red`
+      | `Orange`
+      | `Yellow`
+      | `Green`
+      | `Blue`
+      | `Indigo`
+      | `Violet`
+      | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `meteor`:
+        return EnumMinior.Meteor
+      case `red`:
+        return EnumMinior.Red
+      case `orange`:
+        return EnumMinior.Orange
+      case `yellow`:
+        return EnumMinior.Yellow
+      case `green`:
+        return EnumMinior.Green
+      case `blue`:
+        return EnumMinior.Blue
+      case `indigo`:
+        return EnumMinior.Indigo
+      case `violet`:
+        return EnumMinior.Violet
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumMorpeko.mts
+++ b/src/entity/form/EnumMorpeko.mts
@@ -1,0 +1,51 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Morpeko.
+ */
+export const EnumMorpeko = {
+  Fullbelly: FormBelongToSpecies.builder()
+    .species(Species.Morpeko)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-fullbelly`)
+    .imageSuffix(`-ful-belly`)
+    .build(),
+
+  Hangry: FormBelongToSpecies.builder()
+    .species(Species.Morpeko)
+    .form(1)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-hangry`)
+    .build(),
+
+  /**
+   * Returns all forms of Morpeko.
+   * @returns {FormBelongToSpecies[]} All forms of Morpeko.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumMorpeko.Fullbelly, EnumMorpeko.Hangry]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Fullbelly` | `Hangry` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `fullbelly`:
+      case `full-belly`:
+        return EnumMorpeko.Fullbelly
+      case `hangry`:
+        return EnumMorpeko.Hangry
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumNecrozma.mts
+++ b/src/entity/form/EnumNecrozma.mts
@@ -1,0 +1,79 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Necrozma.
+ */
+export const EnumNecrozma = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.Necrozma)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-normal`)
+    .imageSuffix(``)
+    .build(),
+
+  Dusk: FormBelongToSpecies.builder()
+    .species(Species.Necrozma)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-dusk`)
+    .imageSuffix(`-dusk-mane`)
+    .build(),
+
+  Dawn: FormBelongToSpecies.builder()
+    .species(Species.Necrozma)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-dawn`)
+    .imageSuffix(`-dawn-wings`)
+    .build(),
+
+  Ultra: FormBelongToSpecies.builder()
+    .species(Species.Necrozma)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-ultra`)
+    .build(),
+
+  /**
+   * Returns all forms of Necrozma.
+   * @returns {FormBelongToSpecies[]} All forms of Necrozma.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumNecrozma.Normal,
+      EnumNecrozma.Dusk,
+      EnumNecrozma.Dawn,
+      EnumNecrozma.Ultra
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Normal` | `Dusk` | `Dawn` | `Ultra` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `normal`:
+        return EnumNecrozma.Normal
+      case `dusk`:
+      case `dusk-mane`:
+        return EnumNecrozma.Dusk
+      case `dawn`:
+      case `dawn-wings`:
+        return EnumNecrozma.Dawn
+      case `ultra`:
+        return EnumNecrozma.Ultra
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumOricorio.mts
+++ b/src/entity/form/EnumOricorio.mts
@@ -1,0 +1,75 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Oricorio.
+ */
+export const EnumOricorio = {
+  Baile: FormBelongToSpecies.builder()
+    .species(Species.Oricorio)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-baile`)
+    .build(),
+
+  Pompom: FormBelongToSpecies.builder()
+    .species(Species.Oricorio)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-pompom`)
+    .imageSuffix(`-pom-pom`)
+    .build(),
+
+  Pau: FormBelongToSpecies.builder()
+    .species(Species.Oricorio)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-pau`)
+    .build(),
+
+  Sensu: FormBelongToSpecies.builder()
+    .species(Species.Oricorio)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-sensu`)
+    .build(),
+
+  /**
+   * Returns all forms of Oricorio.
+   * @returns {FormBelongToSpecies[]} All forms of Oricorio.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumOricorio.Baile,
+      EnumOricorio.Pompom,
+      EnumOricorio.Pau,
+      EnumOricorio.Sensu
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Baile` | `Pompom` | `Pau` | `Sensu` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `baile`:
+        return EnumOricorio.Baile
+      case `pompom`:
+        return EnumOricorio.Pompom
+      case `pau`:
+        return EnumOricorio.Pau
+      case `sensu`:
+        return EnumOricorio.Sensu
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumRotom.mts
+++ b/src/entity/form/EnumRotom.mts
@@ -1,0 +1,95 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Rotom.
+ */
+export const EnumRotom = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.Rotom)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`-normal`)
+    .imageSuffix(``)
+    .build(),
+
+  Heat: FormBelongToSpecies.builder()
+    .species(Species.Rotom)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-heat`)
+    .build(),
+
+  Wash: FormBelongToSpecies.builder()
+    .species(Species.Rotom)
+    .form(2)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-wash`)
+    .build(),
+
+  Frost: FormBelongToSpecies.builder()
+    .species(Species.Rotom)
+    .form(3)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-frost`)
+    .build(),
+
+  Fan: FormBelongToSpecies.builder()
+    .species(Species.Rotom)
+    .form(4)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-fan`)
+    .build(),
+
+  Mow: FormBelongToSpecies.builder()
+    .species(Species.Rotom)
+    .form(5)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-mow`)
+    .build(),
+
+  /**
+   * Returns all forms of Rotom.
+   * @returns {FormBelongToSpecies[]} All forms of Rotom.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumRotom.Normal,
+      EnumRotom.Heat,
+      EnumRotom.Wash,
+      EnumRotom.Frost,
+      EnumRotom.Fan,
+      EnumRotom.Mow
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Normal` | `Heat` | `Wash` | `Frost` | `Fan` | `Mow` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `normal`:
+        return EnumRotom.Normal
+      case `heat`:
+        return EnumRotom.Heat
+      case `wash`:
+        return EnumRotom.Wash
+      case `frost`:
+        return EnumRotom.Frost
+      case `fan`:
+        return EnumRotom.Fan
+      case `mow`:
+        return EnumRotom.Mow
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumShaymin.mts
+++ b/src/entity/form/EnumShaymin.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Shaymin.
+ */
+export const EnumShaymin = {
+  Land: FormBelongToSpecies.builder()
+    .species(Species.Shaymin)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-land`)
+    .build(),
+
+  Sky: FormBelongToSpecies.builder()
+    .species(Species.Shaymin)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-sky`)
+    .build(),
+
+  /**
+   * Returns all forms of Shaymin.
+   * @returns {FormBelongToSpecies[]} All forms of Shaymin.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumShaymin.Land, EnumShaymin.Sky]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Land` | `Sky` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `land`:
+        return EnumShaymin.Land
+      case `sky`:
+        return EnumShaymin.Sky
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumTherian.mts
+++ b/src/entity/form/EnumTherian.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Therian.
+ */
+export const EnumTherian = {
+  Incarnate: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-incarnate`)
+    .build(),
+
+  Therian: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-therian`)
+    .build(),
+
+  /**
+   * Returns all forms of Therian.
+   * @returns {FormBelongToSpecies[]} All forms of Therian.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumTherian.Incarnate, EnumTherian.Therian]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Incarnate` | `Therian` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `incarnate`:
+        return EnumTherian.Incarnate
+      case `therian`:
+        return EnumTherian.Therian
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumToxtricity.mts
+++ b/src/entity/form/EnumToxtricity.mts
@@ -1,0 +1,51 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Toxtricity.
+ */
+export const EnumToxtricity = {
+  Amped: FormBelongToSpecies.builder()
+    .species(Species.Toxtricity)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-amped`)
+    .build(),
+
+  Lowkey: FormBelongToSpecies.builder()
+    .species(Species.Toxtricity)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-lowkey`)
+    .imageSuffix(`-low-key`)
+    .build(),
+
+  /**
+   * Returns all forms of Toxtricity.
+   * @returns {FormBelongToSpecies[]} All forms of Toxtricity.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumToxtricity.Amped, EnumToxtricity.Lowkey]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Amped` | `Lowkey` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `amped`:
+        return EnumToxtricity.Amped
+      case `lowkey`:
+      case `low-key`:
+        return EnumToxtricity.Lowkey
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumUnown.mts
+++ b/src/entity/form/EnumUnown.mts
@@ -1,0 +1,349 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Unown.
+ */
+export const EnumUnown = {
+  A: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-a`)
+    .build(),
+
+  B: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-b`)
+    .build(),
+
+  C: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-c`)
+    .build(),
+
+  D: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-d`)
+    .build(),
+
+  E: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-e`)
+    .build(),
+
+  F: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-f`)
+    .build(),
+
+  G: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-g`)
+    .build(),
+
+  H: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-h`)
+    .build(),
+
+  I: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-i`)
+    .build(),
+
+  J: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-j`)
+    .build(),
+
+  K: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-k`)
+    .build(),
+
+  L: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-l`)
+    .build(),
+
+  M: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-m`)
+    .build(),
+
+  N: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-n`)
+    .build(),
+
+  O: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-o`)
+    .build(),
+
+  P: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-p`)
+    .build(),
+
+  Q: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-q`)
+    .build(),
+
+  R: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-r`)
+    .build(),
+
+  S: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-s`)
+    .build(),
+
+  T: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-t`)
+    .build(),
+
+  U: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-u`)
+    .build(),
+
+  V: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-v`)
+    .build(),
+
+  W: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-w`)
+    .build(),
+
+  X: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-x`)
+    .build(),
+
+  Y: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-y`)
+    .build(),
+
+  Z: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-z`)
+    .build(),
+
+  Question: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-question`)
+    .imageSuffix(`-qm`)
+    .build(),
+
+  Exclamation: FormBelongToSpecies.builder()
+    .species(Species.Unown)
+    .form(0)
+    .flags(FormFlag.UnownForm)
+    .spriteSuffix(`-exclamation`)
+    .imageSuffix(`-em`)
+    .build(),
+
+  /**
+   * Returns all forms of Unown.
+   * @returns {FormBelongToSpecies[]} All forms of Unown.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumUnown.A,
+      EnumUnown.B,
+      EnumUnown.C,
+      EnumUnown.D,
+      EnumUnown.E,
+      EnumUnown.F,
+      EnumUnown.G,
+      EnumUnown.H,
+      EnumUnown.I,
+      EnumUnown.J,
+      EnumUnown.K,
+      EnumUnown.L,
+      EnumUnown.M,
+      EnumUnown.N,
+      EnumUnown.O,
+      EnumUnown.P,
+      EnumUnown.Q,
+      EnumUnown.R,
+      EnumUnown.S,
+      EnumUnown.T,
+      EnumUnown.U,
+      EnumUnown.V,
+      EnumUnown.W,
+      EnumUnown.X,
+      EnumUnown.Y,
+      EnumUnown.Z,
+      EnumUnown.Question,
+      EnumUnown.Exclamation
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value:
+      | 'A'
+      | 'B'
+      | 'C'
+      | 'D'
+      | 'E'
+      | 'F'
+      | 'G'
+      | 'H'
+      | 'I'
+      | 'J'
+      | 'K'
+      | 'L'
+      | 'M'
+      | 'N'
+      | 'O'
+      | 'P'
+      | 'Q'
+      | 'R'
+      | 'S'
+      | 'T'
+      | 'U'
+      | 'V'
+      | 'W'
+      | 'X'
+      | 'Y'
+      | 'Z'
+      | 'Question'
+      | 'Exclamation'
+      | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `a`:
+        return EnumUnown.A
+      case `b`:
+        return EnumUnown.B
+      case `c`:
+        return EnumUnown.C
+      case `d`:
+        return EnumUnown.D
+      case `e`:
+        return EnumUnown.E
+      case `f`:
+        return EnumUnown.F
+      case `g`:
+        return EnumUnown.G
+      case `h`:
+        return EnumUnown.H
+      case `i`:
+        return EnumUnown.I
+      case `j`:
+        return EnumUnown.J
+      case `k`:
+        return EnumUnown.K
+      case `l`:
+        return EnumUnown.L
+      case `m`:
+        return EnumUnown.M
+      case `n`:
+        return EnumUnown.N
+      case `o`:
+        return EnumUnown.O
+      case `p`:
+        return EnumUnown.P
+      case `q`:
+        return EnumUnown.Q
+      case `r`:
+        return EnumUnown.R
+      case `s`:
+        return EnumUnown.S
+      case `t`:
+        return EnumUnown.T
+      case `u`:
+        return EnumUnown.U
+      case `v`:
+        return EnumUnown.V
+      case `w`:
+        return EnumUnown.W
+      case `x`:
+        return EnumUnown.X
+      case `y`:
+        return EnumUnown.Y
+      case `z`:
+        return EnumUnown.Z
+      case `question`:
+      case `questionmark`:
+      case `?`:
+        return EnumUnown.Question
+      case `exclamation`:
+      case `exclamationmark`:
+      case `!`:
+        return EnumUnown.Exclamation
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumUrshifu.mts
+++ b/src/entity/form/EnumUrshifu.mts
@@ -1,0 +1,53 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Urshifu.
+ */
+export const EnumUrshifu = {
+  SingleStrike: FormBelongToSpecies.builder()
+    .species(Species.Urshifu)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-singlestrike`)
+    .imageSuffix(`-single-strike`)
+    .build(),
+
+  RapidStrike: FormBelongToSpecies.builder()
+    .species(Species.Urshifu)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-rapidstrike`)
+    .imageSuffix(`-rapid-strike`)
+    .build(),
+
+  /**
+   * Returns all forms of Urshifu.
+   * @returns {FormBelongToSpecies[]} All forms of Urshifu.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumUrshifu.SingleStrike, EnumUrshifu.RapidStrike]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `SingleStrike` | `RapidStrike` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `singlestrike`:
+      case `single-strike`:
+        return EnumUrshifu.SingleStrike
+      case `rapidstrike`:
+      case `rapid-strike`:
+        return EnumUrshifu.RapidStrike
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumVivillon.mts
+++ b/src/entity/form/EnumVivillon.mts
@@ -1,0 +1,258 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Vivillon.
+ */
+export const EnumVivillon = {
+  Archipelago: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`archipelago`)
+    .build(),
+
+  Continental: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`continental`)
+    .build(),
+
+  Elegant: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`elegant`)
+    .build(),
+
+  Garden: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`garden`)
+    .build(),
+
+  Highplains: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`highplains`)
+    .imageSuffix(`hith-plains`)
+    .build(),
+
+  Icysnow: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`icysnow`)
+    .imageSuffix(`icy-snow`)
+    .build(),
+
+  Jungle: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`jungle`)
+    .build(),
+
+  Marine: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`marine`)
+    .build(),
+
+  Meadow: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`meadow`)
+    .build(),
+
+  Modern: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`modern`)
+    .build(),
+
+  Monsoon: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`monsoon`)
+    .build(),
+
+  Ocean: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`ocean`)
+    .build(),
+
+  Polar: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`polar`)
+    .build(),
+
+  River: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`river`)
+    .build(),
+
+  Sandstorm: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`sandstorm`)
+    .build(),
+
+  Savanna: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`savanna`)
+    .build(),
+
+  Sun: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`sun`)
+    .build(),
+
+  Tundra: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`tundra`)
+    .build(),
+
+  Fancy: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`fancy`)
+    .build(),
+
+  Pokeball: FormBelongToSpecies.builder()
+    .species(Species.Vivillon)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .spriteSuffix(`pokeball`)
+    .imageSuffix(`poke-ball`)
+    .build(),
+
+  /**
+   * Returns all forms of Vivillon.
+   * @returns {FormBelongToSpecies[]} All forms of Vivillon.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumVivillon.Archipelago,
+      EnumVivillon.Continental,
+      EnumVivillon.Elegant,
+      EnumVivillon.Garden,
+      EnumVivillon.Highplains,
+      EnumVivillon.Icysnow,
+      EnumVivillon.Jungle,
+      EnumVivillon.Marine,
+      EnumVivillon.Meadow,
+      EnumVivillon.Modern,
+      EnumVivillon.Monsoon,
+      EnumVivillon.Ocean,
+      EnumVivillon.Polar,
+      EnumVivillon.River,
+      EnumVivillon.Sandstorm,
+      EnumVivillon.Savanna,
+      EnumVivillon.Sun,
+      EnumVivillon.Tundra,
+      EnumVivillon.Fancy,
+      EnumVivillon.Pokeball
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value:
+      | `Archipelago`
+      | `Continental`
+      | `Elegant`
+      | `Garden`
+      | `Highplains`
+      | `Icysnow`
+      | `Jungle`
+      | `Marine`
+      | `Meadow`
+      | `Modern`
+      | `Monsoon`
+      | `Ocean`
+      | `Polar`
+      | `River`
+      | `Sandstorm`
+      | `Savanna`
+      | `Sun`
+      | `Tundra`
+      | `Fancy`
+      | `Pokeball`
+      | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `archipelago`:
+        return EnumVivillon.Archipelago
+      case `continental`:
+        return EnumVivillon.Continental
+      case `elegant`:
+        return EnumVivillon.Elegant
+      case `garden`:
+        return EnumVivillon.Garden
+      case `highplains`:
+        return EnumVivillon.Highplains
+      case `icysnow`:
+        return EnumVivillon.Icysnow
+      case `jungle`:
+        return EnumVivillon.Jungle
+      case `marine`:
+        return EnumVivillon.Marine
+      case `meadow`:
+        return EnumVivillon.Meadow
+      case `modern`:
+        return EnumVivillon.Modern
+      case `monsoon`:
+        return EnumVivillon.Monsoon
+      case `ocean`:
+        return EnumVivillon.Ocean
+      case `polar`:
+        return EnumVivillon.Polar
+      case `river`:
+        return EnumVivillon.River
+      case `sandstorm`:
+        return EnumVivillon.Sandstorm
+      case `savanna`:
+        return EnumVivillon.Savanna
+      case `sun`:
+        return EnumVivillon.Sun
+      case `tundra`:
+        return EnumVivillon.Tundra
+      case `fancy`:
+        return EnumVivillon.Fancy
+      case `pokeball`:
+        return EnumVivillon.Pokeball
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumWishiwashi.mts
+++ b/src/entity/form/EnumWishiwashi.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Wishiwashi.
+ */
+export const EnumWishiwashi = {
+  Solo: FormBelongToSpecies.builder()
+    .species(Species.Wishiwashi)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-solo`)
+    .build(),
+
+  School: FormBelongToSpecies.builder()
+    .species(Species.Wishiwashi)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-school`)
+    .build(),
+
+  /**
+   * Returns all forms of Wishiwashi.
+   * @returns {FormBelongToSpecies[]} All forms of Wishiwashi.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumWishiwashi.Solo, EnumWishiwashi.School]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Solo` | `School` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `solo`:
+        return EnumWishiwashi.Solo
+      case `school`:
+        return EnumWishiwashi.School
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumXerneas.mts
+++ b/src/entity/form/EnumXerneas.mts
@@ -1,0 +1,49 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Xerneas.
+ */
+export const EnumXerneas = {
+  Neutral: FormBelongToSpecies.builder()
+    .species(Species.Xerneas)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-neutral`)
+    .build(),
+
+  Active: FormBelongToSpecies.builder()
+    .species(Species.Xerneas)
+    .form(1)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-active`)
+    .build(),
+
+  /**
+   * Returns all forms of Xerneas.
+   * @returns {FormBelongToSpecies[]} All forms of Xerneas.
+   */
+  values(): FormBelongToSpecies[] {
+    return [EnumXerneas.Neutral, EnumXerneas.Active]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(value: `Neutral` | `Active` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `neutral`:
+        return EnumXerneas.Neutral
+      case `active`:
+        return EnumXerneas.Active
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/EnumZygarde.mts
+++ b/src/entity/form/EnumZygarde.mts
@@ -1,0 +1,67 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * Represents available forms of Zygarde.
+ */
+export const EnumZygarde = {
+  FiftyPercent: FormBelongToSpecies.builder()
+    .species(Species.Zygarde)
+    .form(0)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .imageSuffix(`-50`)
+    .build(),
+
+  TenPercent: FormBelongToSpecies.builder()
+    .species(Species.Zygarde)
+    .form(1)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-10%`)
+    .imageSuffix(`-10`)
+    .build(),
+
+  Complete: FormBelongToSpecies.builder()
+    .species(Species.Zygarde)
+    .form(2)
+    .flags(FormFlag.DefaultForm, FormFlag.DisplayFormName)
+    .spriteSuffix(`-complete`)
+    .build(),
+
+  /**
+   * Returns all forms of Zygarde.
+   * @returns {FormBelongToSpecies[]} All forms of Zygarde.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      EnumZygarde.FiftyPercent,
+      EnumZygarde.TenPercent,
+      EnumZygarde.Complete
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `FiftyPercent` | `TenPercent` | `Complete` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `fiftypercent`:
+      case `fifty-percent`:
+        return EnumZygarde.FiftyPercent
+      case `tenpercent`:
+      case `ten-percent`:
+        return EnumZygarde.TenPercent
+      case `complete`:
+        return EnumZygarde.Complete
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/GenderForm.mts
+++ b/src/entity/form/GenderForm.mts
@@ -1,0 +1,57 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * A gender forms.
+ */
+export const GenderForm = {
+  Male: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(0)
+    .flags(FormFlag.GenderForm)
+    .build(),
+
+  Female: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(1)
+    .flags(FormFlag.GenderForm)
+    .build(),
+
+  None: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(2)
+    .flags(FormFlag.GenderlessForm)
+    .build(),
+
+  /**
+   * Returns all gender forms.
+   * @returns {FormBelongToSpecies[]} All gender forms
+   */
+  values: (): FormBelongToSpecies[] => [
+    GenderForm.Male,
+    GenderForm.Female,
+    GenderForm.None
+  ],
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  get: (value: `Male` | `Female` | `None` | null): FormBelongToSpecies => {
+    switch (value?.toLowerCase()) {
+      case `male`:
+        return GenderForm.Male
+      case `female`:
+        return GenderForm.Female
+      case `none`:
+        return GenderForm.None
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/MegaForm.mts
+++ b/src/entity/form/MegaForm.mts
@@ -1,0 +1,67 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * A variant of mega forms.
+ */
+export const MegaForm = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .build(),
+
+  Mega: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(1)
+    .flags(FormFlag.MegaForm, FormFlag.DisplayFormName)
+    .build(),
+
+  MegaX: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(1)
+    .flags(FormFlag.MegaForm, FormFlag.DisplayFormName)
+    .build(),
+
+  MegaY: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(2)
+    .flags(FormFlag.MegaForm, FormFlag.DisplayFormName)
+    .build(),
+
+  /**
+   * Returns all mega forms.
+   * @returns {FormBelongToSpecies[]} All mega forms
+   */
+  values(): FormBelongToSpecies[] {
+    return [MegaForm.Normal, MegaForm.Mega, MegaForm.MegaX, MegaForm.MegaY]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enumeration.
+   *
+   * @param {string} value The name of the form to return
+   * @returns {FormBelongToSpecies} The form with the given name
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum
+   */
+  valueOf(
+    value: Capitalize<`normal` | `mega` | `mega-x` | `mega-y`>
+  ): FormBelongToSpecies {
+    switch (value.toLowerCase()) {
+      case `normal`:
+        return MegaForm.Normal
+      case `mega`:
+        return MegaForm.Mega
+      case `megax`:
+      case `mega-x`:
+        return MegaForm.MegaX
+      case `megay`:
+      case `mega-y`:
+        return MegaForm.MegaY
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/PrimalForm.mts
+++ b/src/entity/form/PrimalForm.mts
@@ -1,0 +1,47 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * A variant of primal forms.
+ */
+export const MegaForm = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .build(),
+
+  Primal: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(1)
+    .flags(FormFlag.AlterForm, FormFlag.DisplayFormName)
+    .build(),
+
+  /**
+   * Returns all mega forms.
+   * @returns {FormBelongToSpecies[]} All mega forms
+   */
+  values(): FormBelongToSpecies[] {
+    return [MegaForm.Normal, MegaForm.Primal]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enumeration.
+   *
+   * @param {string} value The name of the form to return
+   * @returns {FormBelongToSpecies} The form with the given name
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum
+   */
+  valueOf(value: `Normal` | `Primal` | null): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `normal`:
+        return MegaForm.Normal
+      case `primal`:
+        return MegaForm.Primal
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/entity/form/PrimalForm.mts
+++ b/src/entity/form/PrimalForm.mts
@@ -6,7 +6,7 @@ import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exceptio
 /**
  * A variant of primal forms.
  */
-export const MegaForm = {
+export const PrimalForm = {
   Normal: FormBelongToSpecies.builder()
     .species(Species.MissingNo)
     .form(0)
@@ -24,7 +24,7 @@ export const MegaForm = {
    * @returns {FormBelongToSpecies[]} All mega forms
    */
   values(): FormBelongToSpecies[] {
-    return [MegaForm.Normal, MegaForm.Primal]
+    return [PrimalForm.Normal, PrimalForm.Primal]
   },
 
   /**
@@ -37,9 +37,9 @@ export const MegaForm = {
   valueOf(value: `Normal` | `Primal` | null): FormBelongToSpecies {
     switch (value?.toLowerCase()) {
       case `normal`:
-        return MegaForm.Normal
+        return PrimalForm.Normal
       case `primal`:
-        return MegaForm.Primal
+        return PrimalForm.Primal
       default:
         throw new IllegalArgumentException(`Unknown value: ${value}`)
     }

--- a/src/entity/form/RegionalForm.mts
+++ b/src/entity/form/RegionalForm.mts
@@ -1,0 +1,70 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { IllegalArgumentException } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+/**
+ * A variant of regional forms.
+ */
+export const RegionalForm = {
+  Normal: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(0)
+    .flags(FormFlag.DefaultForm)
+    .build(),
+
+  Alolan: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(1)
+    .flags(FormFlag.AlolanForm, FormFlag.DisplayFormName)
+    .build(),
+
+  Galarian: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(2)
+    .flags(FormFlag.GalarianForm, FormFlag.DisplayFormName)
+    .build(),
+
+  Hisuian: FormBelongToSpecies.builder()
+    .species(Species.MissingNo)
+    .form(3)
+    .flags(FormFlag.HisuianForm, FormFlag.DisplayFormName)
+    .build(),
+
+  /**
+   * Returns all regional forms.
+   * @returns {FormBelongToSpecies[]} All regional forms.
+   */
+  values(): FormBelongToSpecies[] {
+    return [
+      RegionalForm.Normal,
+      RegionalForm.Alolan,
+      RegionalForm.Galarian,
+      RegionalForm.Hisuian
+    ]
+  },
+
+  /**
+   * Returns the form with the given name that is a member of this enum.
+   *
+   * @param {string} value The name of the form to return.
+   * @returns {FormBelongToSpecies} The form with the given name.
+   * @throws {IllegalArgumentException} If the given name is not a member of this enum.
+   */
+  valueOf(
+    value: `Normal` | `Alolan` | `Galarian` | `Hisuian` | null
+  ): FormBelongToSpecies {
+    switch (value?.toLowerCase()) {
+      case `normal`:
+        return RegionalForm.Normal
+      case `alolan`:
+        return RegionalForm.Alolan
+      case `galarian`:
+        return RegionalForm.Galarian
+      case `hisuian`:
+        return RegionalForm.Hisuian
+      default:
+        throw new IllegalArgumentException(`Unknown value: ${value}`)
+    }
+  }
+} as const

--- a/src/private/entity/FormBelongToSpeciesImpl.mts
+++ b/src/private/entity/FormBelongToSpeciesImpl.mts
@@ -37,8 +37,11 @@ export class FormBelongToSpeciesBuilderImpl
     return this
   }
 
-  public flags(flags: number): this {
-    this.$flags = flags
+  public flags(...flags: number[]): this {
+    this.$flags |= flags.reduce((acc, flag) => {
+      checkState(flag > -1, `flag must be greater than -1 (was ${flag})`)
+      return acc | flag
+    }, 0)
 
     return this
   }

--- a/src/private/entity/FormBelongToSpeciesImpl.mts
+++ b/src/private/entity/FormBelongToSpeciesImpl.mts
@@ -13,11 +13,15 @@ export class FormBelongToSpeciesBuilderImpl
   public $species: Species | null
   public $form: number
   public $flags: number
+  public $spriteSuffix: string | null
+  public $imageSuffix: string | null
 
   public constructor() {
     this.$species = null
     this.$form = -1
     this.$flags = 0
+    this.$spriteSuffix = null
+    this.$imageSuffix = null
   }
 
   public species(species: Species): this {
@@ -39,10 +43,24 @@ export class FormBelongToSpeciesBuilderImpl
     return this
   }
 
+  public spriteSuffix(spriteSuffix: string): this {
+    this.$spriteSuffix = spriteSuffix
+
+    return this
+  }
+
+  public imageSuffix(imageSuffix: string): this {
+    this.$imageSuffix = imageSuffix
+
+    return this
+  }
+
   public from(value: FormBelongToSpecies): this {
     this.$species = value.species
     this.$form = value.form
     this.$flags = value.flags
+    this.$spriteSuffix = value.spriteSuffix
+    this.$imageSuffix = value.imageSuffix
 
     return this
   }
@@ -51,6 +69,8 @@ export class FormBelongToSpeciesBuilderImpl
     this.$species = null
     this.$form = -1
     this.$flags = 0
+    this.$spriteSuffix = null
+    this.$imageSuffix = null
 
     return this
   }
@@ -74,6 +94,8 @@ export class FormBelongToSpeciesImpl extends FormBelongToSpecies {
   public species: Species
   public form: number
   public flags: number
+  public spriteSuffix: string | null
+  public imageSuffix: string | null
 
   public constructor(builder: FormBelongToSpeciesBuilderImpl) {
     super()
@@ -81,6 +103,8 @@ export class FormBelongToSpeciesImpl extends FormBelongToSpecies {
     this.species = builder.$species!
     this.form = builder.$form
     this.flags = builder.$flags
+    this.spriteSuffix = builder.$spriteSuffix
+    this.imageSuffix = builder.$imageSuffix
   }
 
   public builder(): FormBelongToSpeciesBuilderImpl {

--- a/src/private/entity/FormBelongToSpeciesImpl.mts
+++ b/src/private/entity/FormBelongToSpeciesImpl.mts
@@ -1,3 +1,4 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
 import type { FormBelongToSpeciesBuilder } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
 import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
 import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
@@ -114,6 +115,26 @@ export class FormBelongToSpeciesImpl extends FormBelongToSpecies {
     return new FormBelongToSpeciesBuilderImpl().from(this)
   }
 
+  public isDefaultForm(): boolean {
+    return this.compareForm(FormFlag.DefaultForm)
+  }
+
+  public isMegaForm(): boolean {
+    return this.compareForm(FormFlag.MegaForm)
+  }
+
+  public isAlolan(): boolean {
+    return this.compareForm(FormFlag.AlolanForm)
+  }
+
+  public isGalarian(): boolean {
+    return this.compareForm(FormFlag.GalarianForm)
+  }
+
+  public isHisuian(): boolean {
+    return this.compareForm(FormFlag.HisuianForm)
+  }
+
   public equals(other: any): boolean {
     if (this === other) {
       return true
@@ -128,6 +149,10 @@ export class FormBelongToSpeciesImpl extends FormBelongToSpecies {
 
   public clone(): FormBelongToSpecies {
     return this.builder().build()
+  }
+
+  private compareForm(formFlag: number): boolean {
+    return (this.flags & formFlag) === formFlag
   }
 
   static {

--- a/src/private/entity/FormBelongToSpeciesImpl.mts
+++ b/src/private/entity/FormBelongToSpeciesImpl.mts
@@ -156,7 +156,7 @@ export class FormBelongToSpeciesImpl extends FormBelongToSpecies {
   }
 
   static {
-    asserts<Set<Species>>(FormBelongToSpecies.normalForms)
+    asserts<Set<Species>>(FormBelongToSpecies.customNormalForms)
     asserts<Set<Species>>(FormBelongToSpecies.megaForms)
     asserts<Set<Species>>(FormBelongToSpecies.megaXYForms)
     asserts<Set<Species>>(FormBelongToSpecies.genderForms)
@@ -306,8 +306,8 @@ export class FormBelongToSpeciesImpl extends FormBelongToSpecies {
     ]
 
     normalForms.forEach(
-      FormBelongToSpecies.normalForms.add,
-      FormBelongToSpecies.normalForms
+      FormBelongToSpecies.customNormalForms.add,
+      FormBelongToSpecies.customNormalForms
     )
     megaForms.forEach(
       FormBelongToSpecies.megaForms.add,

--- a/src/private/entity/FormBelongToSpeciesImpl.mts
+++ b/src/private/entity/FormBelongToSpeciesImpl.mts
@@ -47,14 +47,14 @@ export class FormBelongToSpeciesBuilderImpl
     return this
   }
 
-  public spriteSuffix(spriteSuffix: string): this {
-    this.$spriteSuffix = spriteSuffix
+  public spriteSuffix(spriteSuffix?: string): this {
+    this.$spriteSuffix = spriteSuffix || null
 
     return this
   }
 
-  public imageSuffix(imageSuffix: string): this {
-    this.$imageSuffix = imageSuffix
+  public imageSuffix(imageSuffix?: string): this {
+    this.$imageSuffix = imageSuffix || null
 
     return this
   }

--- a/src/util/loader/formLoader.mts
+++ b/src/util/loader/formLoader.mts
@@ -1,0 +1,176 @@
+import { FormFlag } from 'io/github/sayakie/hakase/Constant.mjs'
+import { EnumAegislash } from 'io/github/sayakie/hakase/entity/form/EnumAegislash.mjs'
+import { EnumAlcremie } from 'io/github/sayakie/hakase/entity/form/EnumAlcremie.mjs'
+import { EnumArceus } from 'io/github/sayakie/hakase/entity/form/EnumArceus.mjs'
+import { EnumBasculin } from 'io/github/sayakie/hakase/entity/form/EnumBasculin.mjs'
+import { EnumBurmy } from 'io/github/sayakie/hakase/entity/form/EnumBurmy.mjs'
+import { EnumCalyrex } from 'io/github/sayakie/hakase/entity/form/EnumCalyrex.mjs'
+import { EnumCastform } from 'io/github/sayakie/hakase/entity/form/EnumCastform.mjs'
+import { EnumCherrim } from 'io/github/sayakie/hakase/entity/form/EnumCherrim.mjs'
+import { EnumDarmanitan } from 'io/github/sayakie/hakase/entity/form/EnumDarmanitan.mjs'
+import { EnumDeoxys } from 'io/github/sayakie/hakase/entity/form/EnumDeoxys.mjs'
+import { EnumEiscue } from 'io/github/sayakie/hakase/entity/form/EnumEiscue.mjs'
+import { EnumEternatus } from 'io/github/sayakie/hakase/entity/form/EnumEternatus.mjs'
+import { EnumFlabebe } from 'io/github/sayakie/hakase/entity/form/EnumFlabebe.mjs'
+import { EnumGastrodon } from 'io/github/sayakie/hakase/entity/form/EnumGastrodon.mjs'
+import { EnumGiratina } from 'io/github/sayakie/hakase/entity/form/EnumGiratina.mjs'
+import { EnumGreninja } from 'io/github/sayakie/hakase/entity/form/EnumGreninja.mjs'
+import { EnumGroudon } from 'io/github/sayakie/hakase/entity/form/EnumGroudon.mjs'
+import { EnumHeroDuo } from 'io/github/sayakie/hakase/entity/form/EnumHeroDuo.mjs'
+import { EnumHoopa } from 'io/github/sayakie/hakase/entity/form/EnumHoopa.mjs'
+import { EnumKeldeo } from 'io/github/sayakie/hakase/entity/form/EnumKeldeo.mjs'
+import { EnumKyurem } from 'io/github/sayakie/hakase/entity/form/EnumKyurem.mjs'
+import { EnumLycanroc } from 'io/github/sayakie/hakase/entity/form/EnumLycanroc.mjs'
+import { EnumMeloetta } from 'io/github/sayakie/hakase/entity/form/EnumMeloetta.mjs'
+import { EnumMimikyu } from 'io/github/sayakie/hakase/entity/form/EnumMimikyu.mjs'
+import { EnumMorpeko } from 'io/github/sayakie/hakase/entity/form/EnumMorpeko.mjs'
+import { EnumNecrozma } from 'io/github/sayakie/hakase/entity/form/EnumNecrozma.mjs'
+import { EnumOricorio } from 'io/github/sayakie/hakase/entity/form/EnumOricorio.mjs'
+import { EnumRotom } from 'io/github/sayakie/hakase/entity/form/EnumRotom.mjs'
+import { EnumShaymin } from 'io/github/sayakie/hakase/entity/form/EnumShaymin.mjs'
+import { EnumTherian } from 'io/github/sayakie/hakase/entity/form/EnumTherian.mjs'
+import { EnumToxtricity } from 'io/github/sayakie/hakase/entity/form/EnumToxtricity.mjs'
+import { EnumUnown } from 'io/github/sayakie/hakase/entity/form/EnumUnown.mjs'
+import { EnumUrshifu } from 'io/github/sayakie/hakase/entity/form/EnumUrshifu.mjs'
+import { EnumVivillon } from 'io/github/sayakie/hakase/entity/form/EnumVivillon.mjs'
+import { EnumWishiwashi } from 'io/github/sayakie/hakase/entity/form/EnumWishiwashi.mjs'
+import { EnumXerneas } from 'io/github/sayakie/hakase/entity/form/EnumXerneas.mjs'
+import { EnumZygarde } from 'io/github/sayakie/hakase/entity/form/EnumZygarde.mjs'
+import { MegaForm } from 'io/github/sayakie/hakase/entity/form/MegaForm.mjs'
+import { RegionalForm } from 'io/github/sayakie/hakase/entity/form/RegionalForm.mjs'
+import { FormBelongToSpecies } from 'io/github/sayakie/hakase/entity/FormBelongToSpecies.mjs'
+import { Species } from 'io/github/sayakie/hakase/entity/Species.mjs'
+import { Exception } from 'io/github/sayakie/hakase/util/exception.mjs'
+
+export type FormLink = ReadonlyMap<Species, ReadonlyArray<FormBelongToSpecies>>
+export function loadAllForms(): Promise<FormLink> {
+  const formLink = new Map<Species, FormBelongToSpecies[]>()
+
+  return new Promise<FormLink>((resolve, reject) => {
+    try {
+      formLink.set(Species.Aegislash, EnumAegislash.values())
+      formLink.set(Species.Alcremie, EnumAlcremie.values())
+      formLink.set(Species.Arceus, EnumArceus.values())
+      formLink.set(Species.Basculin, EnumBasculin.values())
+      formLink.set(Species.Burmy, EnumBurmy.values())
+      formLink.set(Species.Calyrex, EnumCalyrex.values())
+      formLink.set(Species.Castform, EnumCastform.values())
+      formLink.set(Species.Cherrim, EnumCherrim.values())
+      formLink.set(Species.Darmanitan, EnumDarmanitan.values())
+      formLink.set(Species.Deoxys, EnumDeoxys.values())
+      formLink.set(Species.Eiscue, EnumEiscue.values())
+      formLink.set(Species.Eternatus, EnumEternatus.values())
+      formLink.set(Species.Flabebe, EnumFlabebe.values())
+      formLink.set(Species.Floette, EnumFlabebe.values())
+      formLink.set(Species.Florges, EnumFlabebe.values())
+      formLink.set(Species.Gastrodon, EnumGastrodon.values())
+      formLink.set(Species.Giratina, EnumGiratina.values())
+      formLink.set(Species.Greninja, EnumGreninja.values())
+      formLink.set(Species.Groudon, EnumGroudon.values())
+      formLink.set(Species.Hoopa, EnumHoopa.values())
+      formLink.set(Species.Keldeo, EnumKeldeo.values())
+      formLink.set(Species.Kyurem, EnumKyurem.values())
+      formLink.set(Species.Lunatone, [
+        RegionalForm.Normal.builder()
+          .species(Species.Lunatone)
+          .spriteSuffix(`-gibbous`)
+          .build()
+      ])
+      formLink.set(Species.Lycanroc, EnumLycanroc.values())
+      formLink.set(Species.Meloetta, EnumMeloetta.values())
+      formLink.set(Species.Mimikyu, EnumMimikyu.values())
+      formLink.set(Species.Morpeko, EnumMorpeko.values())
+      formLink.set(Species.Necrozma, EnumNecrozma.values())
+      formLink.set(Species.Oricorio, EnumOricorio.values())
+      formLink.set(Species.Rotom, EnumRotom.values())
+      formLink.set(Species.Shaymin, EnumShaymin.values())
+      formLink.set(Species.Shellos, EnumGastrodon.values())
+      formLink.set(Species.Silvally, EnumArceus.values())
+      formLink.set(Species.Thundurus, EnumTherian.values())
+      formLink.set(Species.Tornadus, EnumTherian.values())
+      formLink.set(Species.Toxtricity, EnumToxtricity.values())
+      formLink.set(Species.Unown, EnumUnown.values())
+      formLink.set(Species.Urshifu, EnumUrshifu.values())
+      formLink.set(Species.Vivillon, EnumVivillon.values())
+      formLink.set(Species.Wishiwashi, EnumWishiwashi.values())
+      formLink.set(
+        Species.Wormadam,
+        EnumBurmy.values().map(formBelongToWormadam => {
+          if (formBelongToWormadam.form > 0) {
+            return formBelongToWormadam
+              .builder()
+              .flags(
+                formBelongToWormadam.flags & ~FormFlag.DefaultForm,
+                FormFlag.AlterForm
+              )
+              .build()
+          }
+
+          return formBelongToWormadam
+        })
+      )
+      formLink.set(Species.Xerneas, EnumXerneas.values())
+      formLink.set(Species.Zygarde, EnumZygarde.values())
+      formLink.set(Species.Zacian, EnumHeroDuo.values())
+      formLink.set(Species.Zamazenta, EnumHeroDuo.values())
+
+      FormBelongToSpecies.customNormalForms.forEach(species => {
+        formLink.set(species, [
+          RegionalForm.Normal.builder()
+            .species(species)
+            .spriteSuffix(`-normal`)
+            .build()
+        ])
+      })
+
+      FormBelongToSpecies.megaForms.forEach(species => {
+        formLink.set(
+          species,
+          [MegaForm.Normal, MegaForm.Mega].map(form =>
+            form.builder().species(species).build()
+          )
+        )
+      })
+
+      FormBelongToSpecies.megaXYForms.forEach(species => {
+        formLink.set(
+          species,
+          [MegaForm.Normal, MegaForm.MegaX, MegaForm.MegaY].map(form =>
+            form.builder().species(species).build()
+          )
+        )
+      })
+
+      FormBelongToSpecies.alolanForms.forEach(species => {
+        formLink.set(
+          species,
+          [RegionalForm.Normal, RegionalForm.Alolan].map(form =>
+            form.builder().species(species).build()
+          )
+        )
+      })
+
+      FormBelongToSpecies.galarianForms.forEach(species => {
+        formLink.set(
+          species,
+          [RegionalForm.Normal, RegionalForm.Galarian].map(form =>
+            form.builder().species(species).build()
+          )
+        )
+      })
+
+      FormBelongToSpecies.hisuianForms.forEach(species => {
+        formLink.set(
+          species,
+          [RegionalForm.Normal, RegionalForm.Hisuian].map(form =>
+            form.builder().species(species).build()
+          )
+        )
+      })
+
+      resolve(formLink)
+    } catch {
+      reject(new Exception(`Failed to load all forms`))
+    }
+  })
+}


### PR DESCRIPTION
This pr implements the following variant pokemon forms:
* Aegislash
* Alcremie
* Arceus
* Basculin
* Burmy
* Calyrex
* Castform
* Cherrim
* Darmanitan
* Deoxys
* Eiscue
* Eternatus
* Flabebe
* Gastrodon
* Giratina
* Greninja
* Groudon
* Hoopa
* Keldeo
* Kyurem
* Lunatone
* Lycanroc
* Magearna
* Meloetta
* Mimikyu
* Minior
* Morpeko
* Necrozma
* Oricorio
* Rotom
* Shaymin
* Therian
* Toxtricity
* Unown
* Urshifu
* Vivillon
* Wishiwashi
* Wormadam
* Xerneas
* Zygarde