### PR TITLE
Fix literal

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,7 @@ const [ALWAYS, NEVER] = [`always`, `never`]
 
 /**
  * @typedef ESLintAdvancedLinterOptions
- * @property {'@typescript-eslint-parser'} parser
+ * @property {'@typescript-eslint/parser'} parser
  * @property {import('@typescript-eslint/parser').ParserOptions} parserOptions
  *
  * @typedef {import('eslint/lib/shared/types').ConfigData} ESLintBaseLinterOptions


### PR DESCRIPTION
Hi, thanks for this project! 🙌

A quick PR to fix the literal in the config.

As a side note, you may want to switch to the following import, so that you don't need to define your own type for this:

```js
/** @type {import('@typescript-eslint/utils').TSESLint.Linter.Config} */
```

More details about that type here: https://github.com/typescript-eslint/typescript-eslint/issues/2153#issuecomment-637817367